### PR TITLE
Pin chef-metal-vagrant and cheffish gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
 # For testing chef-metal from git master
-#gem 'chef-metal', :git => 'git://github.com/opscode/chef-metal.git'
-gem 'chef-metal', '~> 0.9.0'
-gem 'berkshelf', "~> 2.0"
+# gem 'chef-metal', :git => 'git://github.com/opscode/chef-metal.git'
+gem 'chef-metal',         '~> 0.9.0'
+gem 'berkshelf',          '~> 2.0'
+gem 'chef-metal-vagrant', '~> 0.2.0'
+gem 'cheffish',           '~> 0.3.0'


### PR DESCRIPTION
If you run `rake bundle` with the current Gemfile you'll install incompatible `cheffish` and `chef-metal-vagrant` gems that break the machine resource.

```
NoMethodError
-------------
undefined method `chef_metal' for #<Chef::RunContext:0x007fdb14acba60>


Cookbook Trace:
---------------
  /Users/ryan/.chef/local-mode-cache/cache/cookbooks/ec-harness/recipes/vagrant.rb:8:in `from_file'
  /Users/ryan/.chef/local-mode-cache/cache/cookbooks/ec-harness/recipes/private_chef_ha.rb:3:in `from_file'
```
