### PR TITLE
Add option to use the private IP in a VPC for ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ aws ec2 authorize-security-group-ingress --group-id sg-mysgid --protocol tcp --p
     "region": "us-east-1",
     "vpc_subnet": "subnet-c13410e9",
     "ami_id": "ami-e7e7fc8e",
-    "ssh_username": "root"
+    "ssh_username": "root",
+    "use_private_ip_for_ssh": false
   },
   "default_package": "http://s3.amazonaws.com/opscode-private-chef/el/6/x86_64/private-chef-11.1.3-1.el6.x86_64.rpm?AWSAccessKeyId=getonefromsupport&Expires=thistoo&Signature=andthis",
   "layout": {
@@ -255,7 +256,8 @@ aws ec2 authorize-security-group-ingress --group-id sg-mysgid --protocol tcp --p
     "ssh_username": "root",
     "backend_storage_type": "ebs",
     "ebs_disk_size": "100",
-    "ebs_use_piops": true
+    "ebs_use_piops": true,
+    "use_private_ip_for_ssh": false
   },
   "default_package": "http://s3.amazonaws.com/opscode-private-chef/el/6/x86_64/private-chef-11.1.3-1.el6.x86_64.rpm?AWSAccessKeyId=GetFromSupport&Expires=GetFromSupport&Signature=getfromSupport",
   "manage_package": "http://s3.amazonaws.com/opscode-private-chef/el/6/x86_64/opscode-manage-1.3.1-1.el6.x86_64.rpm?AWSAccessKeyId=GetFromSupport&Expires=GetFromSupport&Signature=getfromSupport",

--- a/config.json.ec2.example
+++ b/config.json.ec2.example
@@ -4,7 +4,8 @@
     "region": "us-east-1",
     "vpc_subnet": "subnet-c13410e9",
     "ami_id": "ami-54ac4d3c",
-    "ssh_username": "root"
+    "ssh_username": "root",
+    "use_private_ip_for_ssh": false
   },
   "default_package": "http://s3.amazonaws.com/opscode-private-chef/el/6/x86_64/private-chef-11.1.3-1.el6.x86_64.rpm?AWSAccessKeyId=getonefromsupport&Expires=thistoo&Signature=andthis",
   "manage_package": "http://s3.amazonaws.com/opscode-private-chef/el/6/x86_64/opscode-manage-1.3.1-1.el6.x86_64.rpm?AWSAccessKeyId=getonefromsupport",

--- a/cookbooks/ec-harness/recipes/ec2.rb
+++ b/cookbooks/ec-harness/recipes/ec2.rb
@@ -10,7 +10,8 @@ with_chef_local_server :chef_repo_path => repo_path,
     File.join(repo_path, 'vendor', 'cookbooks') ]
 
 with_fog_ec2_provisioner :ssh_username => node['harness']['ec2']['ssh_username'],
-    'region' => node['harness']['ec2']['region']
+    'region' => node['harness']['ec2']['region'],
+    :use_private_ip_for_ssh => node['harness']['ec2']['use_private_ip_for_ssh']
 
 with_provisioner_options 'bootstrap_options' => {
       'image_id' => node['harness']['ec2']['ami_id']


### PR DESCRIPTION
This allows you to connect to the instances when the security group only
allows access via the private IP over a VPCs VPN connection.

Note: it has to be set as a symbol and not a string in the
with_fog_ec2_provisioner options, otherwise the option isn't recognized.

I've updated the example config.json file and README to include this option (with a value of false, but showing people that it's there in case it's needed), and if it's left out of the config, it defaults to false also.
