### PR TITLE
READY FOR TESTING: chef-metal 0.11 support

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -24,3 +24,4 @@ private_key_paths	 [keys_dir]
 private_keys		 "#{ENV['USER']}@#{::File.basename(harness_dir)}" => ::File.join(keys_dir, 'id_rsa')
 public_keys		 "#{ENV['USER']}@#{::File.basename(harness_dir)}" => ::File.join(keys_dir, 'id_rsa.pub')
 chef_zero		 :port => find_open_port
+lockfile                 ::File.join(harness_dir, 'chef-client-running.pid')

--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -1,3 +1,15 @@
+def find_open_port
+  port = 8889
+  begin
+    s = TCPServer.new('127.0.0.1', port)
+    s.close
+  rescue
+    port += 1
+    retry
+  end
+  port
+end
+
 current_dir = ::File.dirname(__FILE__)
 harness_dir = ::File.expand_path(::File.join(current_dir, '..'))
 keys_dir = ::File.join(harness_dir, 'keys')
@@ -11,3 +23,4 @@ verify_api_cert          true
 private_key_paths	 [keys_dir]
 private_keys		 "#{ENV['USER']}@#{::File.basename(harness_dir)}" => ::File.join(keys_dir, 'id_rsa')
 public_keys		 "#{ENV['USER']}@#{::File.basename(harness_dir)}" => ::File.join(keys_dir, 'id_rsa.pub')
+chef_zero		 :port => find_open_port

--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -1,8 +1,13 @@
-current_dir = File.dirname(__FILE__)
+current_dir = ::File.dirname(__FILE__)
+harness_dir = ::File.expand_path(::File.join(current_dir, '..'))
+keys_dir = ::File.join(harness_dir, 'keys')
 log_level                :info
 log_location             STDOUT
 node_name                "metal-mastah"
 cache_type               'BasicFile'
 cache_options( :path => "#{ENV['HOME']}/.chef/checksums" )
-cookbook_path            [::File.join(current_dir, '..', 'cookbooks')]
+cookbook_path            [::File.join(harness_dir, 'cookbooks')]
 verify_api_cert          true
+private_key_paths	 [keys_dir]
+private_keys		 "#{ENV['USER']}@#{::File.basename(harness_dir)}" => ::File.join(keys_dir, 'id_rsa')
+public_keys		 "#{ENV['USER']}@#{::File.basename(harness_dir)}" => ::File.join(keys_dir, 'id_rsa.pub')

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cache
 vendor
 users
 data_bags
+chef-client-running.pid

--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,10 @@
 source 'https://rubygems.org'
 
-# For testing chef-metal from git master
-# gem 'chef-metal', :git => 'git://github.com/opscode/chef-metal.git'
-#gem 'chef-metal',         '~> 0.9.0'
-#gem 'chef-metal-vagrant', '~> 0.2.0'
-#gem 'cheffish',           '~> 0.3.0'
-
-gem 'cheffish', :git => 'git://github.com/opscode/cheffish.git'
-gem 'chef-metal', :git => 'git://github.com/opscode/chef-metal.git'
-gem 'chef-metal-fog', :git => 'git://github.com/opscode/chef-metal-fog.git'
-gem 'chef-metal-vagrant', :git => 'git://github.com/opscode/chef-metal-vagrant.git'
-#gem 'chef-metal-ssh', :git => 'git://github.com/double-z/chef-metal-ssh.git'
+gem 'chef-metal',         '~> 0.11.0'
+gem 'chef-metal-vagrant', '~> 0.4.0'
+gem 'chef-metal-fog',     '~> 0.5.0'
+gem 'cheffish',           '~> 0.5.0'
 
 gem 'berkshelf',          '~> 3.0'
-gem 'hashie',             '~> 2.0'
-gem 'chef', :git => 'git://github.com/opscode/chef.git'
+gem 'chef',               '~> 11.14.0.alpha'
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,6 @@ gem 'chef-metal-vagrant', :git => 'git://github.com/opscode/chef-metal-vagrant.g
 #gem 'chef-metal-ssh', :git => 'git://github.com/double-z/chef-metal-ssh.git'
 
 gem 'berkshelf',          '~> 3.0'
+gem 'hashie',             '~> 2.0'
+gem 'chef', :git => 'git://github.com/opscode/chef.git'
+

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,14 @@ source 'https://rubygems.org'
 
 # For testing chef-metal from git master
 # gem 'chef-metal', :git => 'git://github.com/opscode/chef-metal.git'
-gem 'chef-metal',         '~> 0.9.0'
+#gem 'chef-metal',         '~> 0.9.0'
+#gem 'chef-metal-vagrant', '~> 0.2.0'
+#gem 'cheffish',           '~> 0.3.0'
+
+gem 'cheffish', :git => 'git://github.com/opscode/cheffish.git'
+gem 'chef-metal', :git => 'git://github.com/opscode/chef-metal.git'
+gem 'chef-metal-fog', :git => 'git://github.com/opscode/chef-metal-fog.git'
+gem 'chef-metal-vagrant', :git => 'git://github.com/opscode/chef-metal-vagrant.git'
+#gem 'chef-metal-ssh', :git => 'git://github.com/double-z/chef-metal-ssh.git'
+
 gem 'berkshelf',          '~> 3.0'
-gem 'chef-metal-vagrant', '~> 0.2.0'
-gem 'cheffish',           '~> 0.3.0'

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,9 @@ task :default => [:up]
 # Environment variables to be consumed by ec-harness and friends
 harness_dir = ENV['HARNESS_DIR'] = File.dirname(__FILE__)
 
+# just in cases user has a different default Vagrant provider
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
 def get_config
   JSON.parse(File.read('config.json'))
 end

--- a/cookbooks/ec-harness/libraries/fog_helper.rb
+++ b/cookbooks/ec-harness/libraries/fog_helper.rb
@@ -2,7 +2,14 @@
 
 class FogHelper
 
-  def self.load_ini(credentials_ini_file)
+  attr_accessor :ami, :region
+
+  def initialize(params = {})
+    @ami = params[:ami] || 'ami-XXXXXXX'
+    @region = params[:region] || 'us-east-1'
+  end
+
+  def load_ini(credentials_ini_file)
     require 'inifile'
     credentials = {}
     inifile = IniFile.load(File.expand_path(credentials_ini_file))
@@ -19,24 +26,24 @@ class FogHelper
     credentials
   end
 
-  def self.get_aws
+  def get_aws
     require 'fog'
     aws_credentials = load_ini('~/.aws/config')
 
     Fog::Compute.new(:aws_access_key_id => aws_credentials['default'][:access_key_id],
       :aws_secret_access_key => aws_credentials['default'][:secret_access_key],
-      :region => aws_credentials['default'][:region],
+      :region => @region || aws_credentials['default'][:region],
       :provider => 'AWS')
   end
 
-  def self.describe_ami(ami)
+  def describe_ami
     aws = get_aws
-    aws.describe_images('ImageId' => ami).body['imagesSet']
+    aws.describe_images('ImageId' => @ami).body['imagesSet']
   end
 
-  def self.get_root_blockdevice(ami)
-    ami = describe_ami(ami).first
-    ami['blockDeviceMapping'].
+  def get_root_blockdevice
+    ami_desc = describe_ami.first
+    ami_desc['blockDeviceMapping'].
       select { |dev| dev['deviceName'] =~ /sda/ }.
       first['deviceName']
   end

--- a/cookbooks/ec-harness/providers/private_chef_ha.rb
+++ b/cookbooks/ec-harness/providers/private_chef_ha.rb
@@ -17,8 +17,8 @@ def cloud_machine_created?(vmname)
     # Handle the 404 meaning the machine hasn't been created yet
     nodeinfo = {'normal' => {} }
   end
-  provisioner_output = nodeinfo['normal']['provisioner_output']
-  return true if provisioner_output && provisioner_output.has_key?('server_id')
+  driver_info = nodeinfo['normal']['metal']['location']
+  return true if driver_info && driver_info.has_key?('server_id')
   false
 end
 

--- a/cookbooks/ec-harness/providers/private_chef_ha.rb
+++ b/cookbooks/ec-harness/providers/private_chef_ha.rb
@@ -24,12 +24,13 @@ end
 
 action :cloud_create do
  # Dumb hack to populate all of our machines first, for dynamic name/IP provisioners
-  if node['harness']['provider'] == 'ec2'
+  machine_batch 'cloud_create' do
+    action :allocate
     %w(backends frontends).each do |whichend|
       node['harness']['vm_config'][whichend].each do |vmname, config|
-        ChefMetal.with_provisioner_options node['harness']['provisioner_options'][vmname]
 
         machine vmname do
+          add_machine_options node['harness']['provisioner_options'][vmname]
           attribute 'private-chef', privatechef_attributes
           attribute 'root_ssh', node['harness']['root_ssh'].to_hash
           attribute 'cloud', cloud_attributes('ec2')
@@ -46,27 +47,29 @@ end
 action :install do
   %w(backends frontends).each do |whichend|
     node['harness']['vm_config'][whichend].each do |vmname, config|
-      # provisoner_options is set by your provisioner recipe (ex: vagrant.rb)
-      ChefMetal.with_provisioner_options node['harness']['provisioner_options'][vmname]
+      machine_batch vmname do
+        action [:converge]
 
-      machine vmname do
-        attribute 'private-chef', privatechef_attributes
-        attribute 'root_ssh', node['harness']['root_ssh'].to_hash
+        machine vmname do
+          add_machine_options node['harness']['provisioner_options'][vmname]
+          attribute 'private-chef', privatechef_attributes
+          attribute 'root_ssh', node['harness']['root_ssh'].to_hash
 
-        recipe 'private-chef::hostname'
-        recipe 'private-chef::hostsfile'
-        recipe 'private-chef::provision'
-        recipe 'private-chef::bugfixes'
-        recipe 'private-chef::drbd' if node['harness']['vm_config']['backends'].include?(vmname) &&
-          node['harness']['vm_config']['topology'] == 'ha'
-        recipe 'private-chef::provision_phase2'
-        recipe 'private-chef::users' if vmname == bootstrap_node_name
-        recipe 'private-chef::reporting' if node['harness']['reporting_package']
-        recipe 'private-chef::manage' if node['harness']['manage_package'] &&
-          node['harness']['vm_config']['frontends'].include?(vmname)
-        recipe 'private-chef::pushy' if node['harness']['pushy_package']
+          recipe 'private-chef::hostname'
+          recipe 'private-chef::hostsfile'
+          recipe 'private-chef::provision'
+          recipe 'private-chef::bugfixes'
+          recipe 'private-chef::drbd' if node['harness']['vm_config']['backends'].include?(vmname) &&
+            node['harness']['vm_config']['topology'] == 'ha'
+          recipe 'private-chef::provision_phase2'
+          recipe 'private-chef::users' if vmname == bootstrap_node_name
+          recipe 'private-chef::reporting' if node['harness']['reporting_package']
+          recipe 'private-chef::manage' if node['harness']['manage_package'] &&
+            node['harness']['vm_config']['frontends'].include?(vmname)
+          recipe 'private-chef::pushy' if node['harness']['pushy_package']
 
-        converge true
+          converge true
+        end
       end
     end
   end
@@ -79,7 +82,7 @@ action :stop_all_but_master do
     select { |vmname, config| config['bootstrap'] != true }.merge(
     node['harness']['vm_config']['frontends']).each do |vmname, config|
 
-    ChefMetal.with_provisioner_options node['harness']['provisioner_options'][vmname]
+    # with_machine_options node['harness']['provisioner_options'][vmname]
     machine_execute "p-c-c_stop_on_#{vmname}" do
       command '/opt/opscode/bin/private-chef-ctl stop ; exit 0'
       machine vmname
@@ -89,16 +92,10 @@ action :stop_all_but_master do
 end
 
 action :destroy do
-
-  # Bring the backends and frontends online
-  node['harness']['vm_config']['backends'].merge(
-    node['harness']['vm_config']['frontends']).each do |vmname, config|
-
-    machine vmname do
-      action :delete
-    end
+  machine_batch do
+    action :destroy
+    machines search(:node, '*:*').map { |n| n.name }
   end
-
 end
 
 def bootstrap_node_name
@@ -130,7 +127,7 @@ def cloud_attributes(provider)
 
   case provider
   when 'ec2'
-    aws_credentials = ChefMetal::AWSCredentials.new
+    aws_credentials = ChefMetalFog::AWSCredentials.new
     aws_credentials.load_default
     cloud_attrs['aws_access_key_id'] ||= aws_credentials.default[:access_key_id]
     cloud_attrs['aws_secret_access_key'] ||= aws_credentials.default[:secret_access_key]

--- a/cookbooks/ec-harness/providers/private_chef_ha.rb
+++ b/cookbooks/ec-harness/providers/private_chef_ha.rb
@@ -15,10 +15,10 @@ def cloud_machine_created?(vmname)
     nodeinfo = rest.get("/nodes/#{vmname}")
   rescue Net::HTTPServerException
     # Handle the 404 meaning the machine hasn't been created yet
-    nodeinfo = {'normal' => {} }
+    nodeinfo = {'normal' => { 'metal' => {} } }
   end
-  driver_info = nodeinfo['normal']['metal']['location']
-  return true if driver_info && driver_info.has_key?('server_id')
+  driver_info = nodeinfo['normal']['metal']['location'] || {}
+  return true if driver_info.has_key?('server_id')
   false
 end
 

--- a/cookbooks/ec-harness/providers/private_chef_ha.rb
+++ b/cookbooks/ec-harness/providers/private_chef_ha.rb
@@ -25,7 +25,7 @@ end
 action :cloud_create do
  # Dumb hack to populate all of our machines first, for dynamic name/IP provisioners
   machine_batch 'cloud_create' do
-    action :allocate
+    action [:converge]
     %w(backends frontends).each do |whichend|
       node['harness']['vm_config'][whichend].each do |vmname, config|
 
@@ -129,8 +129,8 @@ def cloud_attributes(provider)
   when 'ec2'
     aws_credentials = ChefMetalFog::AWSCredentials.new
     aws_credentials.load_default
-    cloud_attrs['aws_access_key_id'] ||= aws_credentials.default[:access_key_id]
-    cloud_attrs['aws_secret_access_key'] ||= aws_credentials.default[:secret_access_key]
+    cloud_attrs['aws_access_key_id'] ||= aws_credentials.default[:aws_access_key_id]
+    cloud_attrs['aws_secret_access_key'] ||= aws_credentials.default[:aws_secret_access_key]
   end
 
   cloud_attrs

--- a/cookbooks/ec-harness/providers/private_chef_ha.rb
+++ b/cookbooks/ec-harness/providers/private_chef_ha.rb
@@ -29,6 +29,7 @@ action :cloud_create do
     %w(backends frontends).each do |whichend|
       node['harness']['vm_config'][whichend].each do |vmname, config|
 
+        next if cloud_machine_created?(vmname)
         machine vmname do
           add_machine_options node['harness']['provisioner_options'][vmname]
           attribute 'private-chef', privatechef_attributes
@@ -36,8 +37,6 @@ action :cloud_create do
           attribute 'cloud', cloud_attributes('ec2')
           recipe 'private-chef::hostname'
           recipe 'private-chef::ec2'
-
-          not_if { cloud_machine_created?(vmname) }
         end
       end
     end

--- a/cookbooks/ec-harness/recipes/ec2.rb
+++ b/cookbooks/ec-harness/recipes/ec2.rb
@@ -3,12 +3,24 @@
 require 'cheffish'
 require 'chef_metal_fog'
 
+def find_open_port
+  port = 9000
+  begin
+    s = TCPServer.new('127.0.0.1', port)
+    s.close
+  rescue
+    port += 1
+    retry
+  end
+  port
+end
+
 repo_path = node['harness']['repo_path']
 
 with_chef_local_server :chef_repo_path => repo_path,
   :cookbook_path => [ File.join(repo_path, 'cookbooks'),
     File.join(repo_path, 'vendor', 'cookbooks') ],
-    :port => 9010
+    :port => find_open_port
 
 with_driver "fog:AWS:default:#{node['harness']['ec2']['region']}"
 # alternative method:

--- a/cookbooks/ec-harness/recipes/ec2.rb
+++ b/cookbooks/ec-harness/recipes/ec2.rb
@@ -30,6 +30,8 @@ end
 node['harness']['vm_config']['backends'].merge(
   node['harness']['vm_config']['frontends']).each do |vmname, config|
 
+  fog_helper = FogHelper.new(ami: node['harness']['ec2']['ami_id'], region: node['harness']['ec2']['region'])
+
   local_provisioner_options = {
     :bootstrap_options => {
       :key_name => keypair_name,
@@ -40,7 +42,7 @@ node['harness']['vm_config']['backends'].merge(
       :subnet_id => node['harness']['ec2']['vpc_subnet'],
       :associate_public_ip => true,
       :block_device_mapping => [
-        {'DeviceName' => FogHelper.get_root_blockdevice(node['harness']['ec2']['ami_id']),
+        {'DeviceName' => fog_helper.get_root_blockdevice,
           'Ebs.VolumeSize' => 12,
           'Ebs.DeleteOnTermination' => "true"},
         {'DeviceName' => '/dev/sdb', 'VirtualName' => 'ephemeral0'}

--- a/cookbooks/ec-harness/recipes/vagrant.rb
+++ b/cookbooks/ec-harness/recipes/vagrant.rb
@@ -12,9 +12,10 @@ with_chef_local_server :chef_repo_path => repo_path,
   :cookbook_path => [ File.join(repo_path, 'cookbooks'),
     File.join(repo_path, 'vendor', 'cookbooks') ]
 
-vagrant_box node['harness']['vagrant']['box'] do
-  url node['harness']['vagrant']['box_url']
-end
+with_machine_options :vagrant_options => {
+  'vm.box' => node['harness']['vagrant']['box'],
+  'vm.box_url' => node['harness']['vagrant']['box_url']
+}
 
 # set provisioner options for all of our machines
 node['harness']['vm_config']['backends'].merge(
@@ -24,6 +25,6 @@ node['harness']['vm_config']['backends'].merge(
     'vagrant_config' => VagrantConfigHelper.generate_vagrant_config(vmname, config, node)
   }
 
-  node.set['harness']['provisioner_options'][vmname] = ChefMetal.enclosing_provisioner_options.merge(local_provisioner_options)
+  node.set['harness']['provisioner_options'][vmname] = local_provisioner_options
 
 end

--- a/cookbooks/private-chef/providers/backend_vip.rb
+++ b/cookbooks/private-chef/providers/backend_vip.rb
@@ -6,7 +6,7 @@ action :create do
   aws_access_key_id = node['cloud']['aws_access_key_id']
   aws_secret_access_key = node['cloud']['aws_secret_access_key']
   region = node['cloud']['region']
-  server_id = node['provisioner_output']['server_id']
+  server_id = node['metal']['location']['server_id']
   ipaddress = node['private-chef']['backend_vip']['ipaddress']
 
   FogHelper.aws_vpc_assign_secondary_ip('AWS', region, aws_access_key_id, aws_secret_access_key, server_id, ipaddress)

--- a/cookbooks/private-chef/recipes/ec2.rb
+++ b/cookbooks/private-chef/recipes/ec2.rb
@@ -39,11 +39,11 @@ gem_package 'fog' do
   options('--no-rdoc --no-ri')
 end
 
-private_chef_backend_vip node['private-chef']['backend_vip']['ipaddress'] do
-  only_if { node['private-chef']['backends'][node.name] &&
-    node['private-chef']['backends'][node.name]['bootstrap'] == true }
-  not_if "ls /var/opt/opscode/drbd/drbd_ready"
-end
+# private_chef_backend_vip node['private-chef']['backend_vip']['ipaddress'] do
+#   only_if { node['private-chef']['backends'][node.name] &&
+#     node['private-chef']['backends'][node.name]['bootstrap'] == true }
+#   not_if "ls /var/opt/opscode/drbd/drbd_ready"
+# end
 
 directory '/var/opt/opscode/keepalived/bin' do
   owner 'root'

--- a/cookbooks/private-chef/recipes/provision.rb
+++ b/cookbooks/private-chef/recipes/provision.rb
@@ -14,6 +14,7 @@ installer_path = "#{Chef::Config[:file_cache_path]}/#{installer_name}"
 if ::URI.parse(installer_file).absolute?
   remote_file installer_path do
     source installer_file
+    retries 2
     action :create_if_missing
   end
 else

--- a/cookbooks/private-chef/templates/default/custom_backend_ip.vpc.erb
+++ b/cookbooks/private-chef/templates/default/custom_backend_ip.vpc.erb
@@ -10,7 +10,7 @@ when "attach"
   region = "<%= node['cloud']['region'] %>"
   aws_access_key_id = "<%= node['cloud']['aws_access_key_id'] %>"
   aws_secret_access_key = "<%= node['cloud']['aws_secret_access_key'] %>"
-  server_id = "<%= node['provisioner_output']['server_id'] %>"
+  server_id = "<%= node['metal']['location']['server_id'] %>"
   ipaddress = "<%= node['private-chef']['backend_vip']['ipaddress'] %>"
 
   compute = Fog::Compute.new( :region => region,

--- a/cookbooks/private-chef/templates/default/custom_backend_storage.ebs.erb
+++ b/cookbooks/private-chef/templates/default/custom_backend_storage.ebs.erb
@@ -9,7 +9,7 @@ require 'timeout'
 REGION = "<%= node['cloud']['region'] %>"
 AWS_ACCESS_KEY_ID = "<%= node['cloud']['aws_access_key_id'] %>"
 AWS_SECRET_ACCESS_KEY = "<%= node['cloud']['aws_secret_access_key'] %>"
-SERVER_ID = "<%= node['provisioner_output']['server_id'] %>"
+SERVER_ID = "<%= node['metal']['location']['server_id'] %>"
 VOLUME_ID = "<%= node['aws']['ebs_volume'][@bootstrap_host_name]['volume_id'] %>"
 AWS_DEVICE = '/dev/sdc'
 LVM_VG = 'opscode'

--- a/cookbooks/private-chef/templates/default/custom_backend_storage.ebs.erb
+++ b/cookbooks/private-chef/templates/default/custom_backend_storage.ebs.erb
@@ -105,7 +105,7 @@ def attach_volume
       while true
         if `pvscan`.include?(LVM_VG)
           puts "Found LVM volume #{LVM_DEVICE}"
-          system("vgchange --activate y #{LVM_VG}")
+          system("vgchange -a y #{LVM_VG}")
           break
         end
         puts '.'
@@ -218,7 +218,7 @@ def detach_volume
   end
 
   # deactivate the LVM vg to make detach faster
-  system("vgchange --activate n #{LVM_VG}")
+  system("vgchange -a n #{LVM_VG}")
 
   puts "detaching #{VOLUME_ID}"
   compute.detach_volume(VOLUME_ID)


### PR DESCRIPTION
Supporting the new chef-metal 0.11 release:
- Parallelization via machine_batch (used in the cloud_create action)
- New nicer chef-client run output
- New cleaner driver interface with chef-metal 0.11
- improved region handling
- Enable the `metal` command to understand our SSH key scheme
- Improvement to enable multiple ec-metal instances (directories) to run in parallel by automatically finding available TCP ports for chef-zero and decentralizing the `chef-client-running.pid` 
