### PR TITLE
Don't require frontends/backends in the config file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,11 @@ harness_dir = ENV['HARNESS_DIR'] = File.dirname(__FILE__)
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 def get_config
-  JSON.parse(File.read(ENV['ECM_CONFIG'] || 'config.json'))
+  config = JSON.parse(File.read(ENV['ECM_CONFIG'] || 'config.json'))
+  config['layout']['frontends'] ||= {}
+  config['layout']['backends'] ||= {}
+  config['layout']['standalones'] ||= {}
+  config
 end
 
 desc 'Install required Gems into the vendor/bundle directory'

--- a/cookbooks/ec-harness/libraries/vagrant_config.rb
+++ b/cookbooks/ec-harness/libraries/vagrant_config.rb
@@ -29,13 +29,19 @@ class VagrantConfigHelper
       end
     ENDCONFIG
 
-    if vmname == node['harness']['vm_config']['backends'].select { |node,attrs| attrs['bootstrap'] == true }.keys.first
+    if node['harness']['vm_config']['standalones'].nil?
+      bootstrap_vm = node['harness']['vm_config']['backends'].select { |node,attrs| attrs['bootstrap'] == true }.keys.first
+    else
+      bootstrap_vm = node['harness']['vm_config']['standalones'].keys.first
+    end
+
+    if vmname == bootstrap_vm
       vagrant_config += <<-ENDCONFIG
       config.vm.synced_folder "#{File.join(ENV['HARNESS_DIR'], 'users')}", '/srv/piab/users'
       ENDCONFIG
     end
 
-    if node['harness']['vm_config']['backends'].include?(vmname)
+    if (node['harness']['vm_config']['backends'] || {}).include?(vmname)
       vm_disk2 = ::File.join(node['harness']['vms_dir'], vmname, 'disk2.vmdk')
       disk2_size = node['harness']['vagrant']['disk2_size'] || 2
       vagrant_config += <<-ENDCONFIG

--- a/cookbooks/private-chef/templates/default/pc0.res.erb
+++ b/cookbooks/private-chef/templates/default/pc0.res.erb
@@ -6,7 +6,7 @@ resource pc0 {
     rate 40M;
   }
 
-<% node['private-chef']['backends'].each_pair do |name, options| -%>
+<% (node['private-chef']['backends'] || {}).each_pair do |name, options| -%>
   on <%= options[:hostname] || "#{name}.opscode.piab" %> {
     device /dev/drbd0;
     disk /dev/opscode/drbd;

--- a/cookbooks/private-chef/templates/default/private-chef.rb.erb
+++ b/cookbooks/private-chef/templates/default/private-chef.rb.erb
@@ -1,6 +1,6 @@
 topology "<%= node['private-chef']['topology'] %>"
 
-<% node['private-chef']['backends'].each_pair do |name, options| -%>
+<% (node['private-chef']['backends'] || {}).each_pair do |name, options| -%>
 server "<%= options['hostname'] || "#{name}.opscode.piab" %>",
   :ipaddress => "<%= options['ipaddress'] %>",
   <% if options['cluster_ipaddress'] -%>
@@ -10,7 +10,7 @@ server "<%= options['hostname'] || "#{name}.opscode.piab" %>",
   :bootstrap => <%= options['bootstrap'] || false %>
 <% end -%>
 
-<% node['private-chef']['frontends'].each_pair do |name, options| -%>
+<% (node['private-chef']['frontends'] || {}).each_pair do |name, options| -%>
 server "<%= options['hostname'] || "#{name}.opscode.piab" %>",
   :ipaddress => "<%= options['ipaddress'] %>",
   :role => "frontend"


### PR DESCRIPTION
This allows an 'up' command to succeed without frontends or backends being defined in the config file.

There is probably a more elegant way to do this, and I would love to know what it is.
