### PR TITLE
add/remove hosts file no longer part of main tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,32 +23,25 @@ end
 desc 'Bring the VMs online and install+configure Enterprise Chef HA'
 task :up => [:keygen, :cachedir, :config_copy, :bundle, :berks_install] do
   create_users_directory
-  if system("#{harness_dir}/bin/chef-client -z -o ec-harness::private_chef_ha")
-    Rake::Task['add_hosts'].execute unless ENV['disable_hosts']
-  end
+  system("#{harness_dir}/bin/chef-client -z -o ec-harness::private_chef_ha")
 end
 task :start => :up
 
 desc 'Bring the VMs online and then UPGRADE TORTURE'
 task :upgrade_torture => [:keygen, :cachedir, :config_copy, :bundle, :berks_install] do
   create_users_directory
-  if system("#{harness_dir}/bin/chef-client -z -o ec-harness::upgrade_torture")
-    Rake::Task['add_hosts'].execute unless ENV['disable_hosts']
-  end
+  system("#{harness_dir}/bin/chef-client -z -o ec-harness::upgrade_torture")
 end
 
 desc 'Simple upgrade step, installs the package from default_package. Machines must be running'
 task :upgrade => [:keygen, :cachedir, :config_copy, :bundle, :berks_install] do
   create_users_directory
-  if system("#{harness_dir}/bin/chef-client -z -o ec-harness::upgrade")
-    Rake::Task['add_hosts'].execute unless ENV['disable_hosts']
-  end
+  system("#{harness_dir}/bin/chef-client -z -o ec-harness::upgrade")
 end
 
 desc 'Destroy all VMs'
 task :destroy do
   system("#{harness_dir}/bin/chef-client -z -o ec-harness::cleanup")
-  Rake::Task['remove_hosts'].execute unless ENV['disable_hosts']
 end
 task :cleanup => :destroy
 


### PR DESCRIPTION
up, upgrade, etc no longer call the add or remote hosts tasks. (this also removed the disable_hosts env var altogether)

rake add_hosts and remove_hosts task still work as before
