### PR TITLE
add ec2 instance tag key EcMetal

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,6 +45,13 @@ task :destroy do
 end
 task :cleanup => :destroy
 
+
+desc 'Launch ec2 instances'
+task :cloud_create => [:keygen, :cachedir, :config_copy, :bundle, :berks_install] do
+  create_users_directory
+  system("#{harness_dir}/bin/chef-client -z -o ec-harness::cloud_create")
+end
+
 desc 'SSH to a machine like so: rake ssh[backend1]'
 task :ssh, [:machine] do |t,arg|
   Dir.chdir(File.join(harness_dir, 'vagrant_vms')) {

--- a/cookbooks/ec-harness/recipes/cloud_create.rb
+++ b/cookbooks/ec-harness/recipes/cloud_create.rb
@@ -1,0 +1,5 @@
+include_recipe "ec-harness::#{node['harness']['provider']}"
+
+ec_harness_private_chef_ha "launch ec2 instances" do
+  action :cloud_create
+end

--- a/cookbooks/ec-harness/recipes/ec2.rb
+++ b/cookbooks/ec-harness/recipes/ec2.rb
@@ -60,7 +60,10 @@ topo.merged_topology.each do |vmname, config|
           'Ebs.VolumeType' => 'gp2',
           'Ebs.DeleteOnTermination' => "true"},
         {'DeviceName' => '/dev/sdb', 'VirtualName' => 'ephemeral0'}
-      ]
+      ],
+      :tags => {
+        'EcMetal' => node['harness']['ec2']['ec_metal_tag']
+      }
     }
   }
 

--- a/examples/config.json.ec2.example
+++ b/examples/config.json.ec2.example
@@ -6,7 +6,7 @@
     "ami_id": "ami-54ac4d3c",
     "ssh_username": "root",
     "use_private_ip_for_ssh": false,
-    "ec_metal_tag" : "EcMetal key will default to no value if attribute if omitted"
+    "ec_metal_tag" : "EcMetal key will default to no value if attribute is omitted"
   },
   "apply_ec_bugfixes": true,
   "default_package": "http://s3.amazonaws.com/opscode-private-chef/el/6/x86_64/private-chef-11.1.3-1.el6.x86_64.rpm?AWSAccessKeyId=getonefromsupport&Expires=thistoo&Signature=andthis",

--- a/examples/config.json.ec2.example
+++ b/examples/config.json.ec2.example
@@ -5,7 +5,8 @@
     "vpc_subnet": "subnet-c13410e9",
     "ami_id": "ami-54ac4d3c",
     "ssh_username": "root",
-    "use_private_ip_for_ssh": false
+    "use_private_ip_for_ssh": false,
+    "ec_metal_tag" : "EcMetal key will default to no value if attribute if omitted"
   },
   "apply_ec_bugfixes": true,
   "default_package": "http://s3.amazonaws.com/opscode-private-chef/el/6/x86_64/private-chef-11.1.3-1.el6.x86_64.rpm?AWSAccessKeyId=getonefromsupport&Expires=thistoo&Signature=andthis",


### PR DESCRIPTION
will default to no value if not included in config json

intended use is to provide the ability to csta to generate the EcMetal tag value like : rehearsal-{$BUILD_TAG}

This change is in correlation to the jm/csta branch.  I'll probably just merge there when things are ready.
