### PR TITLE
Change the VM host cache mountpoint to /tmp/ecm_cache

### DIFF
--- a/cookbooks/ec-harness/attributes/default.rb
+++ b/cookbooks/ec-harness/attributes/default.rb
@@ -34,7 +34,7 @@ default['harness']['vms_dir'] = File.join(harness_dir, 'vagrant_vms')
 
 # host_cache_path is mapped to /tmp/cache on the VMs
 default['harness']['host_cache_path'] = ENV['CACHE_PATH'] || File.join(harness_dir, 'cache')
-default['harness']['vm_mountpoint'] = '/tmp/cache'
+default['harness']['vm_mountpoint'] = '/tmp/ecm_cache'
 
 # SSH key distribution for inter-machine trust
 default['harness']['root_ssh']['privkey'] = File.read(File.join(repo_path, 'keys', 'id_rsa'))


### PR DESCRIPTION
Changes node['harness']['vm_mountpoint'] from /tmp/cache to /tmp/ecm_cache to avoid conflicting with vagrant-cachier.

There's probably more elegant solutions to this problem:
- unregister vagrant plugins when using ec-metal (unsupported within vagrant)
- ignore or nil-out settings for vagrant plugins if present within cookbooks/ec-harness/libraries/vagrant_config.rb

But this is the cheapest.
