### PR TITLE
Change the VM host cache mountpoint to /tmp/ecm_cache

### DIFF
--- a/cookbooks/ec-harness/attributes/default.rb
+++ b/cookbooks/ec-harness/attributes/default.rb
@@ -34,7 +34,7 @@ default['harness']['vms_dir'] = File.join(harness_dir, 'vagrant_vms')
 
 # host_cache_path is mapped to /tmp/cache on the VMs
 default['harness']['host_cache_path'] = ENV['ECM_CACHE_PATH'] || File.join(harness_dir, 'cache')
-default['harness']['vm_mountpoint'] = '/tmp/cache'
+default['harness']['vm_mountpoint'] = '/tmp/ecm_cache'
 
 # SSH key distribution for inter-machine trust
 default['harness']['root_ssh']['privkey'] = File.read(File.join(repo_path, 'keys', 'id_rsa'))


### PR DESCRIPTION
Accounts for a conflict with vagrant-cachier over use of the /tmp/cache directory.
There are more elegant solutions, this is the cheapest and quickest.
