### PR TITLE
skip the gpg check for our packages

### DIFF
--- a/cookbooks/private-chef/recipes/analytics.rb
+++ b/cookbooks/private-chef/recipes/analytics.rb
@@ -22,6 +22,7 @@ end
 package installer_name do
   source installer_path
   provider Chef::Provider::Package::Dpkg if platform?('ubuntu','debian')
+  options '--nogpgcheck' if platform_family?('rhel') && node['platform_version'].to_i == 5
   action :install
 end
 

--- a/cookbooks/private-chef/recipes/manage.rb
+++ b/cookbooks/private-chef/recipes/manage.rb
@@ -20,6 +20,7 @@ end
 package installer_name do
   source installer_path
   provider Chef::Provider::Package::Dpkg if platform?("ubuntu","debian")
+  options '--nogpgcheck' if platform_family?('rhel') && node['platform_version'].to_i == 5
   action :install
 end
 

--- a/cookbooks/private-chef/recipes/provision.rb
+++ b/cookbooks/private-chef/recipes/provision.rb
@@ -27,8 +27,7 @@ else
   package installer_name do
     source installer_path
     provider Chef::Provider::Package::Dpkg if platform_family?('debian')
-    options '--nogpgcheck' if platform_family?('rhel') &&
-      node['platform_version'].to_i == 5
+    options '--nogpgcheck' if platform_family?('rhel') && node['platform_version'].to_i == 5
     action :install
   end
 

--- a/cookbooks/private-chef/recipes/pushy.rb
+++ b/cookbooks/private-chef/recipes/pushy.rb
@@ -16,6 +16,7 @@ end
 package installer_name do
   source installer_path
   provider Chef::Provider::Package::Dpkg if platform?("ubuntu","debian")
+  options '--nogpgcheck' if platform_family?('rhel') && node['platform_version'].to_i == 5
   action :install
 end
 

--- a/cookbooks/private-chef/recipes/reporting.rb
+++ b/cookbooks/private-chef/recipes/reporting.rb
@@ -22,6 +22,7 @@ end
 package installer_name do
   source installer_path
   provider Chef::Provider::Package::Dpkg if platform?('ubuntu','debian')
+  options '--nogpgcheck' if platform_family?('rhel') && node['platform_version'].to_i == 5
   action :install
 end
 


### PR DESCRIPTION
This was accounted for for the main private-chef packages, but none of the others.
Only effects rhel5.
