### PR TITLE
Use modifyvm to name virtualbox vms as hostname.

### DIFF
--- a/cookbooks/ec-harness/libraries/vagrant_config.rb
+++ b/cookbooks/ec-harness/libraries/vagrant_config.rb
@@ -19,7 +19,7 @@ class VagrantConfigHelper
       config.vm.provider 'virtualbox' do |v|
         v.customize [
           'modifyvm', :id,
-          '--name', "#{vmname}",
+          '--name', "#{config['hostname']}",
           '--memory', "#{config['memory']}",
           '--cpus', "#{config['cpus']}",
           '--natdnshostresolver1', 'on',


### PR DESCRIPTION
This is in an effort to parallelize local testing when using Vagrant; allows for namespacing of VMs within Virtualbox.
