### PR TITLE
Load json from outside the ecm repo.

### DIFF
--- a/cookbooks/ec-harness/attributes/default.rb
+++ b/cookbooks/ec-harness/attributes/default.rb
@@ -1,6 +1,6 @@
 # Load harness attributes from the config file
 harness_dir = ENV['HARNESS_DIR']
-config_json = JSON.parse(File.read(File.join(harness_dir, ENV['ECM_CONFIG'] || 'config.json')))
+config_json = JSON.parse(File.read( ENV['ECM_CONFIG'] || File.join(harness_dir, 'config.json')))
 default['harness']['harness_dir'] = harness_dir
 default['harness']['provider'] = config_json['provider']
 default['harness']['vagrant'] = config_json['vagrant_options']


### PR DESCRIPTION
Allows for config json files that exist outside of the ./examples dir to be loaded via global environmental variable.
