### PR TITLE
WIP osc to cs12 upgrade changes

### DIFF
--- a/cookbooks/private-chef/recipes/ec2.rb
+++ b/cookbooks/private-chef/recipes/ec2.rb
@@ -78,6 +78,7 @@ cookbook_file '/opt/opscode/embedded/cookbooks/private-chef/templates/default/cl
   group 'root'
   mode '0755'
   only_if { topology.is_backend?(node.name) }
+  not_if { node['osc-install'] }
   subscribes :create, "package[#{installer_name}]", :immediately
   action :nothing
 end

--- a/cookbooks/private-chef/recipes/provision_phase2.rb
+++ b/cookbooks/private-chef/recipes/provision_phase2.rb
@@ -128,7 +128,7 @@ ruby_block 'p-c-c osc upgrade' do
   block do
     begin
       tries ||= 2
-      cmd = Mixlib::ShellOut.new('yes | /opt/opscode/bin/private-chef-ctl upgrade')
+      cmd = Mixlib::ShellOut.new('/opt/opscode/bin/private-chef-ctl upgrade --yes --org-name ecmetal --full-org-name ecmetalorg')
       cmd.run_command
       if cmd.error?
         cmd.error!


### PR DESCRIPTION
The documentation for upgrades is still in progress. ec-metal is being updated to follow the docs.  For now I've forced the update orgs to "ecmetal".  When this works I'll move that in the configuration.
