### PR TITLE
Machine batch fix for vagrant.

### DIFF
--- a/cookbooks/ec-harness/providers/private_chef_ha.rb
+++ b/cookbooks/ec-harness/providers/private_chef_ha.rb
@@ -45,11 +45,11 @@ action :cloud_create do
 end
 
 action :install do
-  machine_batch 'vagrant_create' do
+  machine_batch 'server_create' do
     action [:converge]
+    
     topo = TopoHelper.new(ec_config: node['harness']['vm_config'], exclude_layers: analytics_layers)
     topo.merged_topology.each do |vmname, config|
-
 
       machine vmname do
         add_machine_options node['harness']['provisioner_options'][vmname]
@@ -82,10 +82,11 @@ action :install do
   end
 
   if node['harness']['analytics_package'] && is_analytics?
-    topo_analytics = TopoHelper.new(ec_config: node['harness']['vm_config'], include_layers: analytics_layers)
-    topo_analytics.merged_topology.each do |vmname, config|
-      machine_batch vmname do
-        action [:converge]
+    machine_batch 'analytics_create' do
+      action [:converge]
+
+      topo_analytics = TopoHelper.new(ec_config: node['harness']['vm_config'], include_layers: analytics_layers)
+      topo_analytics.merged_topology.each do |vmname, config|
 
         machine vmname do
           add_machine_options node['harness']['provisioner_options'][vmname]

--- a/cookbooks/ec-harness/providers/private_chef_ha.rb
+++ b/cookbooks/ec-harness/providers/private_chef_ha.rb
@@ -45,10 +45,11 @@ action :cloud_create do
 end
 
 action :install do
-  topo = TopoHelper.new(ec_config: node['harness']['vm_config'], exclude_layers: analytics_layers)
-  topo.merged_topology.each do |vmname, config|
-    machine_batch vmname do
-      action [:converge]
+  machine_batch 'vagrant_create' do
+    action [:converge]
+    topo = TopoHelper.new(ec_config: node['harness']['vm_config'], exclude_layers: analytics_layers)
+    topo.merged_topology.each do |vmname, config|
+
 
       machine vmname do
         add_machine_options node['harness']['provisioner_options'][vmname]


### PR DESCRIPTION
Previously, we were creating a machine_batch resource for each machine resource. Causing the VMs to be created and provisioned in serial. This create 1 machine_batch for all the nodes of the chef server or analytics topo, allowing for the creation of VMs in serial (restriction of vagrant's virtualbox provider), but provisioning to happen in parallel.

This was already done correctly in cloud_create.
