### PR TITLE
Fix bug and default keypair_path to ~/.ssh

### DIFF
--- a/lib/provider_specific/ec2_specific.rb
+++ b/lib/provider_specific/ec2_specific.rb
@@ -4,15 +4,17 @@ module EcMetal
   class Ec2Specific < ProviderSpecific
     # Creates the keys needed to create the vagrant nodes.  Don't bother recreating if keys already exist
     def node_keys(keydir)
-      if ENV['ECM_KEYPAIR_PATH'].nil? || ENV['ECM_KEYPAIR_NAME'].nil?
-        raise "Keypair path and name must be set for EC2 runs (ECM_KEYPAIR_PATH, ECM_KEYPAIR_NAME)"
+      if ENV['ECM_KEYPAIR_NAME'].nil?
+        raise "ECM_KEYPAIR_NAME must be set for EC2 runs. ECM_KEYPAIR_PATH defaults to ~/.ssh"
       end
+
+      keypair_path = ENV['ECM_KEYPAIR_PATH'] || '~/.ssh'
 
       FileUtils.mkdir_p keydir
       if Dir["#{keydir}/*"].empty?
         private_key, public_key = normalize_keypair_name(ENV['ECM_KEYPAIR_NAME'])
-        FileUtils.ln_s("#{ENV['ECM_KEYPAIR_PATH']}/#{private_key}", "#{keydir}/#{private_key}")
-        FileUtils.ln_s("#{ENV['ECM_KEYPAIR_PATH']}/#{public_key}", "#{keydir}/#{public_key}")
+        FileUtils.ln_s("#{keypair_path}/#{private_key}", "#{keydir}/#{private_key}")
+        FileUtils.ln_s("#{keypair_path}/#{public_key}", "#{keydir}/#{public_key}")
       end
     end
 
@@ -20,7 +22,7 @@ module EcMetal
 
     # @returns public_key_name, private_key_name
     def normalize_keypair_name(keypair_name)
-      if keypair_name != 'id_rsa'
+      if keypair_name == 'id_rsa'
         return ['id_rsa', 'id_rsa.pub']
       end
 


### PR DESCRIPTION
This is in response to a PR comment @oferrigni made on https://github.com/opscode/ec-metal/pull/87
