### PR TITLE
add live streaming output for commands run via EcMetal::Api#self.run

### DIFF
--- a/lib/api.rb
+++ b/lib/api.rb
@@ -101,10 +101,12 @@ module EcMetal
     # Shells out, ensures error messages are recorded and throws an exception on non-zero responses
     # timeout is in tenths of seconds (default 600 last checked)
     def self.run(command, timeout = nil)
+      STDOUT.sync = true
+
       printable_env = ENV.to_a.map{|val| val.join('=')}.join(' ')
       puts "#{command} from #{harness_dir} with env #{printable_env}"
 
-      shellout_params = {:env => ENV.to_hash, :cwd => harness_dir}
+      shellout_params = {:env => ENV.to_hash, :cwd => harness_dir, :live_stream => STDOUT}
       shellout_params[:timeout] = timeout unless timeout.nil?
 
       # TODO(jmink) determine why this env var needs to be set externally


### PR DESCRIPTION
Yup. /Really/ helps when debugging.
