### PR TITLE
Don't use harness dir to find cookbooks

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -13,7 +13,7 @@ log_location             STDOUT
 node_name                'metal-provisioner'
 cache_type               'BasicFile'
 cache_options( :path => "#{ENV['HOME']}/.chef/checksums" )
-cookbook_path            [local_cookbooks, ::File.join(harness_dir, 'cookbooks'), File.join(repo, 'cookbooks')].uniq
+cookbook_path            [local_cookbooks, File.join(repo, 'cookbooks')].uniq
 verify_api_cert          true
 private_key_paths	 [keys_dir]
 

--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -2,7 +2,7 @@ current_dir = ::File.dirname(__FILE__)
 harness_dir = ENV['HARNESS_DIR']
 repo = ENV['ECM_CHEF_REPO']
 local_cookbooks = File.join(Pathname.new(File.dirname(__FILE__)).parent.to_s, 'cookbooks')
-ENV['LOCAL_COOKBOOKS'] = local_cookbooks
+ENV['ECM_LOCAL_COOKBOOKS'] = local_cookbooks
 FileUtils.mkdir_p(repo)
 chef_repo_path repo
 keys_dir = ::File.join(repo, 'keys')
@@ -13,9 +13,7 @@ log_location             STDOUT
 node_name                'metal-provisioner'
 cache_type               'BasicFile'
 cache_options( :path => "#{ENV['HOME']}/.chef/checksums" )
-cookbook_path            [::File.join(harness_dir, 'cookbooks'),
-                         File.join(repo, 'cookbooks'),
-                         ]
+cookbook_path            [local_cookbooks, ::File.join(harness_dir, 'cookbooks'), File.join(repo, 'cookbooks')].uniq
 verify_api_cert          true
 private_key_paths	 [keys_dir]
 

--- a/cookbooks/ec-harness/recipes/ec2.rb
+++ b/cookbooks/ec-harness/recipes/ec2.rb
@@ -7,9 +7,9 @@ harness_dir = node['harness']['harness_dir']
 repo_path = node['harness']['repo_path']
 
 with_chef_local_server :chef_repo_path => repo_path,
-  :cookbook_path => [ File.join(harness_dir, 'cookbooks'),
+  :cookbook_path => [ ENV['ECM_LOCAL_COOKBOOKS'],
                       File.join(repo_path, 'cookbooks'),
-    File.join(repo_path, 'vendor', 'cookbooks') ],
+    File.join(repo_path, 'vendor', 'cookbooks') ].uniq,
     :port => 9010.upto(9999)
 
 with_driver "fog:AWS:default:#{node['harness']['ec2']['region']}"

--- a/cookbooks/ec-harness/recipes/vagrant.rb
+++ b/cookbooks/ec-harness/recipes/vagrant.rb
@@ -10,9 +10,9 @@ vagrant_cluster vms_dir
 
 directory repo_path
 with_chef_local_server :chef_repo_path => repo_path,
-  :cookbook_path => [File.join(harness_dir, 'cookbooks'),
+  :cookbook_path => [ENV['ECM_LOCAL_COOKBOOKS'],
                      File.join(repo_path, 'cookbooks'),
-    File.join(repo_path, 'vendor', 'cookbooks') ],
+    File.join(repo_path, 'vendor', 'cookbooks') ].uniq,
     :port => 9010.upto(9999)
 
 with_machine_options :vagrant_options => {

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -109,8 +109,7 @@ module EcMetal
       shellout_params = {:env => ENV.to_hash, :cwd => harness_dir, :live_stream => STDOUT}
       shellout_params[:timeout] = timeout unless timeout.nil?
 
-      # TODO(jmink) determine why this env var needs to be set externally
-      run = Mixlib::ShellOut.new("BERKSHELF_CHEF_CONFIG=$PWD/berks_config #{command}", shellout_params)
+      run = Mixlib::ShellOut.new("#{command}", shellout_params)
       run.run_command
       puts run.stdout
       puts "error messages for #{command}: #{run.stderr}" unless run.stderr.nil?


### PR DESCRIPTION
For projects that want to use ec-metal with the harness dir not being the ec-metal repo (like CSTA) the local cookbooks (ec-common, ec-harness, and private-chef) need to be locatable.

This change causes the recipes to look in ECM_LOCAL_COOKBOOKS instead of harness dir for those cookbooks.  I feel dirty using an env var so if people have a better suggestion I'm all ears.

I tested this manually by bringing up an ec2 server.  Running vagrant now.

Note: This makes provision[initial] from the jm/upgrade branch of csta run without error.
