### PR TITLE
add log_level and force_formatter options to rake up task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'json'
 require 'fileutils'
 require './cookbooks/ec-common/libraries/topo_helper.rb'
+
 require_relative 'lib/api.rb'
 Dir["lib/tasks/*.rake"].each { |t| load t }
 
@@ -18,9 +19,11 @@ task :bundle do
   EcMetal::Api.bundle
 end
 
-desc 'Bring the VMs online and install+configure Enterprise Chef HA'
+desc 'Bring the VMs online and install/configure Enterprise Chef. Optionally: "rake up debug" and/or "rake up force_formatter" for verbose output'
 task :up => :setup do
-  EcMetal::Api.up
+  log_level = ARGV.select {|i| i =~ /debug|info|warn|error|fatal/}.last
+  force_formatter = ARGV.select {|i| i =~ /force(-|_)formatter/}.last
+  EcMetal::Api.up(log_level, force_formatter)
 end
 task :start => :up
 

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -18,19 +18,19 @@ module EcMetal
       ENV['ECM_CHEF_REPO'] = repo_dir
 
       # Optionally pass "debug" argument from the "rake up" task to the chef-client run
-      be_chef_client_command = "bundle exec chef-client --config #{KNIFE} -z -o ec-harness::private_chef_ha"
+      chef_client_command = "bundle exec chef-client --config #{KNIFE} -z -o ec-harness::private_chef_ha"
 
       if log_level
-        be_chef_client_command += " -l #{log_level}"
+        chef_client_command += " -l #{log_level}"
         puts "Setting chef-client log_level to #{log_level}"
       end
 
       if force_formatter
-        be_chef_client_command += " --force-formatter"
+        chef_client_command += " --force-formatter"
         puts "Adding '--force-formatter' to chef-client command"
       end
       
-      run(be_chef_client_command, 60*MINUTE_IN_DEC_SECS)
+      run(chef_client_command, 60*MINUTE_IN_DEC_SECS)
     end
 
     def self.destroy

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -10,11 +10,27 @@ module EcMetal
     MINUTE_IN_DEC_SECS = 600
     KNIFE = File.join(File.dirname(File.dirname(__FILE__)), '.chef', 'knife.rb')
 
-    def self.up
+    # Executes chef-client with the recipe that creates a chef server. Optionally consumes subcommands
+    # from the "rake up" task --log_level and --force-formatter commands to offer more verbose output
+    def self.up(log_level=nil, force_formatter=nil)
       create_users_directory
       ENV['HARNESS_DIR'] = harness_dir
       ENV['ECM_CHEF_REPO'] = repo_dir
-      run("bundle exec chef-client --config #{KNIFE} -z -o ec-harness::private_chef_ha", 60*MINUTE_IN_DEC_SECS)
+
+      # Optionally pass "debug" argument from the "rake up" task to the chef-client run
+      be_chef_client_command = "bundle exec chef-client --config #{KNIFE} -z -o ec-harness::private_chef_ha"
+
+      if log_level
+        be_chef_client_command += " -l #{log_level}"
+        puts "Setting chef-client log_level to #{log_level}"
+      end
+
+      if force_formatter
+        be_chef_client_command += " --force-formatter"
+        puts "Adding '--force-formatter' to chef-client command"
+      end
+      
+      run(be_chef_client_command, 60*MINUTE_IN_DEC_SECS)
     end
 
     def self.destroy


### PR DESCRIPTION
The "--force-formatter" option for chef-client gives the more verbose output from chef-zero-initated chef-client runs.
