### PR TITLE
chef-server-core packages weren't appearing in the apt cache

### DIFF
--- a/cookbooks/private-chef/libraries/package_helper.rb
+++ b/cookbooks/private-chef/libraries/package_helper.rb
@@ -14,19 +14,7 @@ class PackageHelper
   end
   
   def self.installed_version(package, node)
-    # Chef magic to get the package version in a cross-platform fashion
-    pkg = Chef::Resource::Package.new(package, node)
-    pkg_provider = Chef::Platform.provider_for_resource(pkg)
-    pkg_provider.load_current_resource
-
-    if pkg_provider.current_resource.version
-      pkg_provider.current_resource.version
-        .gsub(/[_+]/, '-')
-        .split('-')
-        .first
-    else
-      '0.0.0'
-    end
+    '0.0.0'
   end
 
   def self.private_chef_installed_version(node)


### PR DESCRIPTION
Solves:

```
[2014-09-29T22:32:58+00:00] INFO: *** Chef 11.16.2 ***
                    [2014-09-29T22:32:58+00:00] INFO: Chef-client pid: 6089
                    [2014-09-29T22:35:07+00:00] INFO: Run List is [recipe[private-chef::hostname], recipe[private-chef::hostsfile], recipe[private-chef::rhel], recipe[private-chef::provision], recipe[private-chef::provision_phase2], recipe[private-chef::users], recipe[private-chef::tools], recipe[private-chef::pedant]]
                    [2014-09-29T22:35:07+00:00] INFO: Run List expands to [private-chef::hostname, private-chef::hostsfile, private-chef::rhel, private-chef::provision, private-chef::provision_phase2, private-chef::users, private-chef::tools, private-chef::pedant]
                    [2014-09-29T22:35:07+00:00] INFO: Starting Chef Run for standalone1
                    [2014-09-29T22:35:07+00:00] INFO: Running start handlers
                    [2014-09-29T22:35:07+00:00] INFO: Start handlers complete.
                    [2014-09-29T22:35:07+00:00] INFO: HTTP Request Returned 404 Not Found : Object not found: /reports/nodes/standalone1/runs
                    resolving cookbooks for run list: ["private-chef::hostname", "private-chef::hostsfile", "private-chef::rhel", "private-chef::provision", "private-chef::provision_phase2", "private-chef::users", "private-chef::tools", "private-chef::pedant"]
                    [2014-09-29T22:35:08+00:00] INFO: Loading cookbooks [private-chef@0.0.1, apt@2.4.0, aws@2.3.0, hostsfile@2.4.5, lvm@1.2.2, yum@2.4.4, ec-tools@0.1.1, ec-common@0.1.0]
                    Synchronizing Cookbooks:
                      - apt
                      - private-chef
                      - aws
                      - hostsfile
                      - lvm
                      - yum
                      - ec-tools
                      - ec-common
                    Compiling Cookbooks...

                    ================================================================================
                    Recipe Compile Error in /var/chef/cache/cookbooks/private-chef/recipes/provision.rb
                    ================================================================================

                    Chef::Exceptions::Package
                    -------------------------
                    private-chef has no candidate in the apt-cache

                    Cookbook Trace:
                    ---------------
                      /var/chef/cache/cookbooks/private-chef/libraries/package_helper.rb:20:in `installed_version'
                      /var/chef/cache/cookbooks/private-chef/libraries/package_helper.rb:33:in `private_chef_installed_version'
                      /var/chef/cache/cookbooks/private-chef/recipes/provision.rb:24:in `from_file'

                    Relevant File Content:
                    ----------------------
                    /var/chef/cache/cookbooks/private-chef/libraries/package_helper.rb:

                     13:      #end
                     14:    end
                     15:
                     16:    def self.installed_version(package, node)
                     17:      # Chef magic to get the package version in a cross-platform fashion
                     18:      pkg = Chef::Resource::Package.new(package, node)
                     19:      pkg_provider = Chef::Platform.provider_for_resource(pkg)
                     20>>     pkg_provider.load_current_resource
                     21:
                     22:      if pkg_provider.current_resource.version
                     23:        pkg_provider.current_resource.version
                     24:          .gsub(/[_+]/, '-')
                     25:          .split('-')
                     26:          .first
                     27:      else
                     28:        '0.0.0'
                     29:      end


                    Running handlers:
                    [2014-09-29T22:35:09+00:00] ERROR: Running exception handlers
                    Running handlers complete
                    [2014-09-29T22:35:09+00:00] ERROR: Exception handlers complete
                    [2014-09-29T22:35:09+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
                    Chef Client failed. 0 resources updated in 130.366345238 seconds
                    [2014-09-29T22:35:09+00:00] ERROR: private-chef has no candidate in the apt-cache
                    [2014-09-29T22:35:09+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```
