### PR TITLE
Create an 'ecm' binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 Berksfile.lock
 .bundle
-bin
+bin/*
 config.json
 clients
 nodes
@@ -14,3 +14,5 @@ chef-client-running.pid
 chef-repo
 
 *.lock
+
+!bin/ecm

--- a/bin/ecm
+++ b/bin/ecm
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+Signal.trap('INT') { exit 1 }
+
+$:.push File.expand_path('../../lib', __FILE__)
+$stdout.sync = true
+
+require 'api'


### PR DESCRIPTION
Just points to ec-metal/lib/api for now, but 

```
require 'ec_metal/config'
require 'pry'
binding.pry
```

with @patrick-wright's pw/config-api for great justice!
