### PR TITLE
update rhel gpg key url

### DIFF
--- a/cookbooks/private-chef/recipes/rhel.rb
+++ b/cookbooks/private-chef/recipes/rhel.rb
@@ -1,6 +1,6 @@
 if platform_family?('rhel') 
   remote_file "/tmp/packages@opscode.com.gpg.key" do
-    source "http://apt.opscode.com/packages@opscode.com.gpg.key"
+    source "https://downloads.getchef.com/chef.gpg.key"
   end
 
   execute "rpm --import /tmp/packages\@opscode.com.gpg.key"


### PR DESCRIPTION
It was broke because we retired "apt.opscode.com", not it won't be.
