### PR TITLE
Attempt to detect chef-server-core along with private-chef

### DIFF
--- a/cookbooks/private-chef/libraries/package_helper.rb
+++ b/cookbooks/private-chef/libraries/package_helper.rb
@@ -2,8 +2,10 @@
 
 class PackageHelper
 
+  UNINSTALLED_VERSION = '0.0.0'
+
   def self.package_version(package)
-    version = '0.0.0'
+    version = UNINSTALLED_VERSION
     if ( (package =~ /^private-chef/) || (package =~ /^chef-server-(\d+)/) )
       version = package.gsub(/[_+%]/, '-').split('-')[2]
     elsif package =~ /^chef-server-core/
@@ -19,8 +21,9 @@ class PackageHelper
     pkg_provider = Chef::Platform.provider_for_resource(pkg)
     begin
       pkg_provider.load_current_resource
+    # raises an exception if chef-server-core is installed and you query for private-chef
     rescue Chef::Exceptions::Package
-      return '0.0.0'
+      return UNINSTALLED_VERSION
     end
 
     if pkg_provider.current_resource.version
@@ -29,13 +32,15 @@ class PackageHelper
         .split('-')
         .first
     else
-      '0.0.0'
+      UNINSTALLED_VERSION
     end
   end
 
   def self.private_chef_installed_version(node)
     private_chef_version = self.installed_version('private-chef', node)
-    private_chef_version != '0.0.0' ?  private_chef_version : self.installed_version('chef-server-core', node)
+    return private_chef_version unless private_chef_version == UNINSTALLED_VERSION
+    # Fall back to chef-server-core if private-chef isn't installed
+    self.installed_version('chef-server-core', node)
   end
 
   def self.osc_version_installed_version(node)

--- a/cookbooks/private-chef/libraries/package_helper.rb
+++ b/cookbooks/private-chef/libraries/package_helper.rb
@@ -12,12 +12,16 @@ class PackageHelper
       return version
     end
   end
-  
+
   def self.installed_version(package, node)
     # Chef magic to get the package version in a cross-platform fashion
     pkg = Chef::Resource::Package.new(package, node)
     pkg_provider = Chef::Platform.provider_for_resource(pkg)
-    pkg_provider.load_current_resource
+    begin
+      pkg_provider.load_current_resource
+    rescue Chef::Exceptions::Package
+      return '0.0.0'
+    end
 
     if pkg_provider.current_resource.version
       pkg_provider.current_resource.version
@@ -30,7 +34,8 @@ class PackageHelper
   end
 
   def self.private_chef_installed_version(node)
-    self.installed_version('private-chef', node)
+    private_chef_version = self.installed_version('private-chef', node)
+    private_chef_version != '0.0.0' ?  private_chef_version : self.installed_version('chef-server-core', node)
   end
 
   def self.osc_version_installed_version(node)


### PR DESCRIPTION
Would appreciate feedback on more Ruby-Idiomatic ways to do this, but:
1.  `pkg_provider.load_current_resource` raises an `Chef::Exceptions::Package` if `chef-server-core` is installed and you query for `private-chef`  -- I think this is because of [1] below.   So rescue on that and return `0.0.0` which is the equivalent of uninstalled
2.  Modify the `private_chef_installed_version` method to fall back to `chef-server-core` if `private-chef` isn't installed.

[1]

```
root@backend1:~# apt-cache showpkg chef-server-core
Package: chef-server-core
Versions: 
12.0.0-rc.6-1 (/var/lib/dpkg/status)
 Description Language: 
                 File: /var/lib/dpkg/status
                  MD5: a5a909d9290df04b6b8e337089019c28


Reverse Depends: 
Dependencies: 
12.0.0-rc.6-1 - private-chef (0 (null)) private-chef:i386 (0 (null)) private-chef (0 (null)) private-chef:i386 (0 (null)) 
Provides: 
12.0.0-rc.6-1 - 
Reverse Provides: 
```
