### PR TITLE
Pedant fixes and improvements

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ end
 
 # run chef-client commands not part of the api
 def shellout_chef_client(run_list)
-  sh("#{EcMetal::Api.harness_dir}/bin/chef-client -z -o #{run_list} --force_formatter")
+  sh("#{EcMetal::Api.harness_dir}/bin/chef-client -z -o #{run_list} --force-formatter")
 end
 
 desc 'Install required Gems into the vendor/bundle directory'
@@ -30,6 +30,12 @@ task :up => :setup do
   EcMetal::Api.up(log_level)
 end
 task :start => :up
+
+desc 'Run pedant tests on all machines'
+task :pedant => :setup do
+  shellout_chef_client('ec-harness::pedant')
+end
+task :verify => :pedant
 
 desc 'Bring the VMs online and then UPGRADE TORTURE'
 task :upgrade_torture => :setup do

--- a/cookbooks/ec-harness/attributes/default.rb
+++ b/cookbooks/ec-harness/attributes/default.rb
@@ -7,13 +7,13 @@ default['harness']['vagrant'] = config_json['vagrant_options']
 default['harness']['ec2'] = config_json['ec2_options']
 default['harness']['vm_config'] = config_json['layout']
 default['harness']['default_package'] = ENV['ECM_DEFAULT_PACKAGE'] || config_json['default_package']
-default['harness']['run_pedant'] = config_json['run_pedant'] || false
+default['harness']['run_pedant'] = config_json['run_pedant'] || true
 default['harness']['osc_install'] = config_json['osc_install'] || false
 default['harness']['osc_upgrade'] = config_json['osc_upgrade'] || false
 default['harness']['packages'] = config_json['packages']
 
 # Provide an option to not monkeypatch the bugfixes
-default['harness']['apply_ec_bugfixes'] = config_json['apply_ec_bugfixes']
+default['harness']['apply_ec_bugfixes'] = config_json['apply_ec_bugfixes'] || false
 
 # Provide an option to intentionally bomb out before running the upgrade reconfigure, so it can be done manually
 default['harness']['vm_config']['lemme_doit'] = config_json['lemme_doit'] || false

--- a/cookbooks/ec-harness/providers/private_chef_ha.rb
+++ b/cookbooks/ec-harness/providers/private_chef_ha.rb
@@ -107,6 +107,11 @@ action :pedant do
   topo = TopoHelper.new(ec_config: node['harness']['vm_config'], include_layers: ec_layers)
   topo.merged_topology.each do |vmname, config|
 
+    # Skip on non-bootstrap backend
+    # FIXME: this assumes no failover has occured, better to make it conditional
+    next if topo.is_backend?(vmname) && topo.is_ha? &&
+      config['bootstrap'] != true
+
     machine_execute "run_pedant_on#{vmname}" do
       command '/opt/opscode/bin/private-chef-ctl test'
       machine vmname

--- a/cookbooks/ec-harness/recipes/pedant.rb
+++ b/cookbooks/ec-harness/recipes/pedant.rb
@@ -1,0 +1,7 @@
+# encoding: utf-8
+
+include_recipe "ec-harness::#{node['harness']['provider']}"
+
+ec_harness_private_chef_ha "run_pedant_on_#{node['harness']['provider']}" do
+  action :pedant
+end


### PR DESCRIPTION
- Don't pedant on the non-bootstrap backend, it will always fail
- Add an `ec-harness::pedant` recipe and rake pedant/verify command
- bugfix for force-formatter flag in Rakefile
- Now that pedant is our friend, change the default of run_pedant to true
