### PR TITLE
Additional fixes to make CS12 and loadtesting work

### DIFF
--- a/cookbooks/ec-harness/recipes/ec2.rb
+++ b/cookbooks/ec-harness/recipes/ec2.rb
@@ -38,13 +38,14 @@ topo.merged_topology.each do |vmname, config|
   fog_helper = FogHelper.new(ami: node['harness']['ec2']['ami_id'], region: node['harness']['ec2']['region'])
 
   local_provisioner_options = {
+    :ssh_username => config['ssh_username'] || node['harness']['ec2']['ssh_username'],
     :bootstrap_options => {
       :key_name => keypair_name,
-      :flavor_id => config['instance_type'] || 'c3.large',
+      :flavor_id => config['instance_type'] || 'm3.xlarge',
       :region => node['harness']['ec2']['region'],
       :ebs_optimized => config['ebs_optimized'] || false,
-      :image_id => node['harness']['ec2']['ami_id'],
-      :subnet_id => node['harness']['ec2']['vpc_subnet'],
+      :image_id => config['ami_id'] || node['harness']['ec2']['ami_id'],
+      :subnet_id => config['vpc_subnet'] || node['harness']['ec2']['vpc_subnet'],
       :associate_public_ip => true,
       :block_device_mapping => [
         {'DeviceName' => fog_helper.get_root_blockdevice,

--- a/cookbooks/ec-harness/templates/default/opscode-analytics.rb.erb
+++ b/cookbooks/ec-harness/templates/default/opscode-analytics.rb.erb
@@ -1,1 +1,0 @@
-analytics_fqdn "<%= node['private-chef']['analytics_fqdn'] %>"

--- a/cookbooks/loadtester_host/recipes/default.rb
+++ b/cookbooks/loadtester_host/recipes/default.rb
@@ -114,7 +114,10 @@ end
 
 include_recipe 'docker'
 
-chef_gem 'knife-container'
+gem_package 'knife-container' do
+  gem_binary('/opt/chef/embedded/bin/gem')
+  options('--no-rdoc --no-ri')
+end
 
 directory '/etc/chef/secure/certs' do
   owner "root"

--- a/cookbooks/private-chef/files/default/cluster.sh.erb
+++ b/cookbooks/private-chef/files/default/cluster.sh.erb
@@ -33,9 +33,9 @@ function transition
   log_me "Transitioning to $1"
   case "$1" in
     master)
-      if [ -x '/var/opt/opscode/keepalived/bin/custom_backend_storage' ]; then
+      if [ -x '/var/opt/opscode/keepalived/bin/ha_backend_storage' ]; then
           log_me "Attempting CUSTOM BACKEND STORAGE takeover"
-          /var/opt/opscode/keepalived/bin/custom_backend_storage attach >> $LOGNAME 2>&1
+          /var/opt/opscode/keepalived/bin/ha_backend_storage attach >> $LOGNAME 2>&1
           if [ $? -gt 0 ]; then
             error_exit "CUSTOM BACKEND STORAGE attach failed"
           else
@@ -71,9 +71,9 @@ function transition
       <%- end -%>
 <%- end -%>
 
-      if [ -x '/var/opt/opscode/keepalived/bin/custom_backend_ip' ]; then
+      if [ -x '/var/opt/opscode/keepalived/bin/ha_backend_ip' ]; then
           log_me "Attempting CUSTOM BACKEND IP primary takeover"
-          /var/opt/opscode/keepalived/bin/custom_backend_ip attach >> $LOGNAME 2>&1
+          /var/opt/opscode/keepalived/bin/ha_backend_ip attach >> $LOGNAME 2>&1
           if [ $? -gt 0 ]; then
             error_exit "CUSTOM BACKEND IP attach failed"
           else
@@ -88,9 +88,9 @@ function transition
       /opt/opscode/bin/private-chef-ctl graceful-kill <%= service %> || error_exit "Cannot kill <%= service %>"
 <%- end -%>
 
-      if [ -x '/var/opt/opscode/keepalived/bin/custom_backend_storage' ]; then
+      if [ -x '/var/opt/opscode/keepalived/bin/ha_backend_storage' ]; then
           log_me "Attempting CUSTOM BACKEND STORAGE detach"
-          /var/opt/opscode/keepalived/bin/custom_backend_storage detach >> $LOGNAME 2>&1
+          /var/opt/opscode/keepalived/bin/ha_backend_storage detach >> $LOGNAME 2>&1
           if [ $? -gt 0 ]; then
             error_exit "CUSTOM BACKEND STORAGE detach failed"
           else
@@ -109,9 +109,9 @@ function transition
         done
       fi
 
-      if [ -x '/var/opt/opscode/keepalived/bin/custom_backend_ip' ]; then
+      if [ -x '/var/opt/opscode/keepalived/bin/ha_backend_ip' ]; then
           log_me "Attempting CUSTOM BACKEND IP to go standby"
-          /var/opt/opscode/keepalived/bin/custom_backend_ip detach >> $LOGNAME 2>&1
+          /var/opt/opscode/keepalived/bin/ha_backend_ip detach >> $LOGNAME 2>&1
           if [ $? -gt 0 ]; then
             error_exit "CUSTOM BACKEND IP detach failed"
           else

--- a/cookbooks/private-chef/libraries/opc_users.rb
+++ b/cookbooks/private-chef/libraries/opc_users.rb
@@ -69,19 +69,32 @@ class Chef
               action :create
             end
 
-            execute "create_user_#{username}_in_org_#{orgname}" do
+            execute "create_user_#{username}" do
               # it goes USERNAME FIRST_NAME [MIDDLE_NAME] LAST_NAME EMAIL PASSWORD options
               cmd_args = [
                           knife_opc_cmd, 'user', 'create',
-                          username, username, username,
-                          "#{username}@#{orgname}.org",
-                          username,
-                          '-o', orgname,
+                          username, #username
+                          username, #first_name
+                          username, #last_name
+                          "#{username}@#{orgname}.org", #email
+                          username, #password
                           '-f' "#{dot_chef}/#{username}.pem"
                          ]
               command cmd_args.join(' ')
               action :run
             end
+
+            execute "associate_user_#{username}_to_org_#{orgname}" do
+              cmd_args = [
+                          knife_opc_cmd, 'org', 'user', 'add',
+                          orgname,
+                          username,
+                          '--admin'
+                         ]
+              command cmd_args.join(' ')
+              action :run
+            end
+
           end
         end
       end

--- a/cookbooks/private-chef/recipes/ec2.rb
+++ b/cookbooks/private-chef/recipes/ec2.rb
@@ -58,7 +58,7 @@ directory '/var/opt/opscode/keepalived/bin' do
   only_if { topology.is_backend?(node.name) }
 end
 
-template '/var/opt/opscode/keepalived/bin/custom_backend_ip' do
+template '/var/opt/opscode/keepalived/bin/ha_backend_ip' do
   source 'custom_backend_ip.vpc.erb'
   owner 'root'
   group 'root'

--- a/cookbooks/private-chef/templates/default/opscode-analytics.rb.erb
+++ b/cookbooks/private-chef/templates/default/opscode-analytics.rb.erb
@@ -1,6 +1,6 @@
 analytics_fqdn "<%= node['analytics']['analytics_fqdn'] %>"
 
-topology "<%= node['analytics']['analytics_topology'] %>"
+topology "<%= node['analytics']['analytics_topology'] || 'standalone' %>"
 
 <% (node['analytics']['analytics_backends'] || {}).each_pair do |name, options| -%>
 server "<%= options['hostname'] || "#{name}.opscode.piab" %>",

--- a/examples/config.json.loadtesting-ha-cs12
+++ b/examples/config.json.loadtesting-ha-cs12
@@ -3,17 +3,17 @@
   "ec2_options": {
     "region": "us-west-2",
     "vpc_subnet": "subnet-b2bb82f4",
-    "ami_id": "ami-7df0bd4d",
-    "ssh_username": "ec2-user",
+    "ami_id": "ami-3d50120d",
+    "ssh_username": "ubuntu",
     "backend_storage_type": "drbd",
     "ebs_disk_size": "100",
     "use_private_ip_for_ssh": false,
     "elb": true
   },
-  "default_package": "https://web-dl.packagecloud.io/chef/stable/packages/el/6/private-chef-11.2.5-1.el6.x86_64.rpm",
-  "manage_package": "https://web-dl.packagecloud.io/chef/stable/packages/el/6/opscode-manage-1.6.2-1.el6.x86_64.rpm",
-  "reporting_package": "https://web-dl.packagecloud.io/chef/stable/packages/el/6/opscode-reporting-1.1.5-1.el6.x86_64.rpm",
-  "analytics_package": "https://web-dl.packagecloud.io/chef/stable/packages/el/6/opscode-analytics-1.0.4-1.el6.x86_64.rpm",
+  "default_package":   "https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/trusty/chef-server-core_12.0.0-rc.6-1_amd64.deb",
+  "manage_package":    "https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/precise/opscode-manage_1.6.2-1_amd64.deb",
+  "reporting_package": "https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/precise/opscode-reporting_1.1.7-1_amd64.deb",
+  "analytics_package": "https://web-dl.packagecloud.io/chef/stable/packages/ubuntu/precise/opscode-analytics_1.0.4-1_amd64.deb",
   "apply_ec_bugfixes": false,
   "lemme_doit": false,
   "loadtesters": {
@@ -25,16 +25,16 @@
   },
   "layout": {
     "topology": "ha",
-    "api_fqdn": "api.rhel.aws",
-    "manage_fqdn": "manage.rhel.aws",
-    "analytics_fqdn": "analytics.rhel.aws",
+    "api_fqdn": "api.trusty.aws",
+    "manage_fqdn": "manage.trusty.aws",
+    "analytics_fqdn": "analytics.trusty.aws",
     "configuration": {
       "postgresql": {
 	      "max_connections": 1500,
         "log_min_duration_statement": 500
       },
       "oc_id": {
-	      "administrators": ["pinkiepie", "soarin"]
+        "administrators": ["pinkiepie", "soarin"]
       },
       "opscode_erchef": {
 	      "depsolver_worker_count": 4,
@@ -54,53 +54,56 @@
       },
       "nginx": {
         "enable_non_ssl": true
+      },
+      "license": {
+        "nodes": 100000
       }
     },
     "backend_vip": {
-      "hostname": "backend.rhel.aws",
+      "hostname": "backend.trusty.aws",
       "ipaddress": "33.33.33.9",
       "device": "eth0",
       "heartbeat_device": "eth0"
     },
     "analytics_standalones": {
       "analytics-standalone1": {
-        "hostname": "ip-rh-analytics-standalone1.rhel.aws",
+        "hostname": "ip-ub-analytics-standalone1.trusty.aws",
         "ebs_optimized": true,
         "instance_type": "m3.xlarge",
         "bootstrap": true
       }
     },
    "frontends": {
-      "ip-rh-frontend1": {
-        "hostname": "ip-rh-frontend1.rhel.aws",
+      "ip-ub-frontend1": {
+        "hostname": "ip-ub-frontend1.trusty.aws",
         "ebs_optimized": true,
         "instance_type": "m3.xlarge"
       },
-      "ip-rh-frontend2": {
-        "hostname": "ip-rh-frontend2.rhel.aws",
+      "ip-ub-frontend2": {
+        "hostname": "ip-ub-frontend2.trusty.aws",
         "ebs_optimized": true,
         "instance_type": "m3.xlarge"
       },
-      "ip-rh-frontend3": {
-        "hostname": "ip-rh-frontend3.rhel.aws",
+      "ip-ub-frontend3": {
+        "hostname": "ip-ub-frontend3.trusty.aws",
         "ebs_optimized": true,
         "instance_type": "m3.xlarge"
       },
-      "ip-rh-frontend4": {
-        "hostname": "ip-rh-frontend4.rhel.aws",
+      "ip-ub-frontend4": {
+        "hostname": "ip-ub-frontend4.trusty.aws",
         "ebs_optimized": true,
         "instance_type": "m3.xlarge"
       }
    },
    "backends": {
-      "ip-rh-backend1": {
-        "hostname": "ip-rh-backend1.rhel.aws",
+      "ip-ub-backend1": {
+        "hostname": "ip-ub-backend1.trusty.aws",
         "ebs_optimized": true,
         "instance_type": "m3.xlarge",
 	      "bootstrap": true
       },
-      "ip-rh-backend2": {
-        "hostname": "ip-rh-backend2.rhel.aws",
+      "ip-ub-backend2": {
+        "hostname": "ip-ub-backend2.trusty.aws",
         "ebs_optimized": true,
         "instance_type": "m3.xlarge",
 	      "bootstrap": false
@@ -108,11 +111,9 @@
     },
    "loadtesters": {
       "loadtester_spec": {
-        "hostname": "loadtester1.rhel.aws",
+        "hostname": "loadtester1.trusty.aws",
         "ebs_optimized": true,
-        "instance_type": "m3.2xlarge",
-	"ssh_username": "ubuntu",
-        "ami_id": "ami-3d50120d"
+        "instance_type": "m3.2xlarge"
       }
     }
   }

--- a/lib/tasks/loadtesting.rake
+++ b/lib/tasks/loadtesting.rake
@@ -7,7 +7,7 @@ ENV['ECM_CHEF_REPO'] = EcMetal::Api.repo_dir
 desc 'Spin up load-testing machines'
 task :loadtesters do
   # run twice because AWS
-  system("#{EcMetal::Api.harness_dir}/bin/chef-client -z -o ec-harness::loadtesters")
+  sh("#{EcMetal::Api.harness_dir}/bin/chef-client -z -o ec-harness::loadtesters")
 end
 task :setup_loadtest => :loadtesters
 
@@ -27,7 +27,7 @@ task :run_loadtest do
         v.map { |i| search_req += "name:*loadtester-#{i} OR " }
         search_req.chomp!(' OR ')
         puts "Starting group at #{Time.now}: #{search_req}"
-        system("#{EcMetal::Api.harness_dir}/bin/knife ssh '#{search_req}' -a cloud.public_ipv4 'for i in {1..#{subwave_size}}; do sudo docker run -d ponyville/ubuntu; done' -x ubuntu -i #{EcMetal::Api.repo_dir}/keys/id_rsa")
+        sh("#{EcMetal::Api.harness_dir}/bin/knife ssh '#{search_req}' -a cloud.public_ipv4 'for i in {1..#{subwave_size}}; do sudo docker run -d ponyville/ubuntu; done' -x ubuntu -i #{EcMetal::Api.repo_dir}/keys/id_rsa")
         puts "Finishing group at #{Time.now}: #{search_req}"
         puts "----------------------------------------------------------------\n\n\n\n"
       end
@@ -37,7 +37,7 @@ end
 
 desc 'Destroy the load-testing machines'
 task :cleanup_loadtest do
-  system("#{EcMetal::Api.harness_dir}/bin/chef-client -z -o ec-harness::loadtesters_destroy")
+  sh("#{EcMetal::Api.harness_dir}/bin/chef-client -z -o ec-harness::loadtesters_destroy")
 end
 task :destroy_loadtest => :cleanup_loadtest
 
@@ -47,5 +47,5 @@ end
 
 desc 'Spin up load-testing machines'
 task :loadtest => [:berks_install] do
-  system("#{EcMetal::Api.harness_dir}/bin/chef-client -z -o ec-harness::loadtesters")
+  sh("#{EcMetal::Api.harness_dir}/bin/chef-client -z -o ec-harness::loadtesters")
 end


### PR DESCRIPTION
- VIP assignment now works correctly in CS12
- Fix user creation so that all users are admins
- Set a sane default for analytics topology
- Fix knife-container installation on loadtester_host
- Make it possible to use a different AMI type, subnet, ssh_username for each machine within it's config definition like:

``` json
     "loadtester_spec": {
        "hostname": "loadtester1.rhel.aws",
        "ebs_optimized": true,
        "instance_type": "m3.2xlarge",
        "ssh_username": "ubuntu",
        "ami_id": "ami-3d50120d"
      }
```
