### PR TITLE
Fix user/org creation on Vagrant+CS12 and improve Pedant behavior

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -12,4 +12,4 @@ cookbook 'yum-epel'
 cookbook 'docker', '~> 0.0'
 cookbook 'chef-client'
 
-cookbook 'ec-tools', :git => 'https://github.com/patrick-wright/ec-tools'
+cookbook 'ec-tools', :git => 'https://github.com/irvingpop/ec-tools'

--- a/cookbooks/private-chef/recipes/provision_phase2.rb
+++ b/cookbooks/private-chef/recipes/provision_phase2.rb
@@ -76,6 +76,7 @@ end
 execute 'fix-migration-state' do
   command '/opt/opscode/embedded/bin/bundle exec bin/partybus init'
   cwd '/opt/opscode/embedded/service/partybus'
+  environment 'PATH' => '/opt/opscode/embedded/bin:/bin:/sbin:/usr/bin:/usr/sbin'
   action :run
   not_if 'ls /var/opt/opscode/upgrades/migration-level'
   not_if 'ls /tmp/private-chef-perform-upgrade'


### PR DESCRIPTION
On Vagrant we depend on the `virtual_hosts` config to statically define the /etc/hosts file on each VM.  That's a bummer because in AWS we point `api.mydomain` at localhost, which improves the reliability of Pedant tests and also ensures knife-opc commands go to backend1 when backend1 is the bootstrap node.

Also, now that chef-metal grabs chef 12 by default, we get SSL errors from the stricter `ssl_verify_mode` setting, addressed by https://github.com/patrick-wright/ec-tools/pull/1

fixes #122 
