### PR TITLE
Org torture test v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .bundle
 bin/*
 config.json
+config.json.*
 clients
 nodes
 vagrant_vms
@@ -12,6 +13,7 @@ data_bags
 chef-client-running.pid
 chef-repo
 .chef/trusted_certs/
+berks_configs
 
 *.lock
 

--- a/cookbooks/ec-harness/attributes/default.rb
+++ b/cookbooks/ec-harness/attributes/default.rb
@@ -18,6 +18,9 @@ default['harness']['apply_ec_bugfixes'] = config_json['apply_ec_bugfixes'] || fa
 # Provide an option to intentionally bomb out before running the upgrade reconfigure, so it can be done manually
 default['harness']['vm_config']['lemme_doit'] = config_json['lemme_doit'] || false
 
+# Provide an option to run the "org torturer" which creates 900 orgs.  see: https://gist.github.com/irvingpop/bf4b983b5db7b5b9cbc7
+default['harness']['org_torture'] = config_json['org_torture'] || false
+
 # addon packages
 default['harness']['manage_package'] = ENV['ECM_MANAGE_PACKAGE'] || config_json['manage_package']
 default['harness']['reporting_package'] = ENV['ECM_REPORTING_PACKAGE'] || config_json['reporting_package']

--- a/cookbooks/ec-harness/libraries/ec2_config.rb
+++ b/cookbooks/ec-harness/libraries/ec2_config.rb
@@ -36,6 +36,9 @@ class Ec2ConfigHelper
         :tags => {
           'EcMetal' => node['harness']['ec2']['ec_metal_tag']
         }
+      },
+      :convergence_options => {
+        :install_sh_arguments => '-P chefdk'
       }
     }
 
@@ -72,6 +75,9 @@ class Ec2ConfigHelper
         # :tags => {
         #   'EcMetal' => node['harness']['ec2']['ec_metal_tag']
         # }
+      },
+      :convergence_options => {
+        :install_sh_arguments => '-P chefdk'
       }
     }
 

--- a/cookbooks/ec-harness/providers/private_chef_ha.rb
+++ b/cookbooks/ec-harness/providers/private_chef_ha.rb
@@ -12,7 +12,6 @@ end
 
 action :install do
   log "action :install, I don't do anything anymore!"
-        recipe 'private-chef::org_torture'
 end
 
 action :pedant do

--- a/cookbooks/ec-harness/providers/private_chef_ha.rb
+++ b/cookbooks/ec-harness/providers/private_chef_ha.rb
@@ -12,6 +12,7 @@ end
 
 action :install do
   log "action :install, I don't do anything anymore!"
+        recipe 'private-chef::org_torture'
 end
 
 action :pedant do

--- a/cookbooks/ec-harness/recipes/bootstrap_server.rb
+++ b/cookbooks/ec-harness/recipes/bootstrap_server.rb
@@ -31,7 +31,7 @@ machine_batch 'bootstrap_node' do
       recipe 'private-chef::users' if vmname == ecm_topo_chef.bootstrap_node_name
       recipe 'private-chef::loadbalancer' if ecm_topo_chef.is_frontend?(vmname) &&
         node['harness']['provider'] == 'ec2'
-      recipe 'private-chef::org_torture'
+      recipe 'private-chef::org_torture' if node['harness']['org_torture'] == true
 
       converge true
     end

--- a/cookbooks/ec-harness/recipes/bootstrap_server.rb
+++ b/cookbooks/ec-harness/recipes/bootstrap_server.rb
@@ -31,6 +31,7 @@ machine_batch 'bootstrap_node' do
       recipe 'private-chef::users' if vmname == ecm_topo_chef.bootstrap_node_name
       recipe 'private-chef::loadbalancer' if ecm_topo_chef.is_frontend?(vmname) &&
         node['harness']['provider'] == 'ec2'
+      recipe 'private-chef::org_torture'
 
       converge true
     end

--- a/cookbooks/ec-harness/recipes/loadtesters.rb
+++ b/cookbooks/ec-harness/recipes/loadtesters.rb
@@ -91,7 +91,9 @@ node['harness']['vm_config']['loadtesters'].each do |vmname, config|
           machine_options machine_options_for_provider(vmname, config)
           add_machine_options(
             convergence_options: {
-              ssl_verify_mode: :verify_none
+              ssl_verify_mode: :verify_none,
+              install_sh_arguments: '',
+              chef_version: '12.2.1'
             }
           )
           attribute 'root_ssh', node['harness']['root_ssh'].to_hash

--- a/cookbooks/ec-harness/recipes/loadtesters.rb
+++ b/cookbooks/ec-harness/recipes/loadtesters.rb
@@ -30,7 +30,7 @@ berks_config = ::File.join(node['harness']['repo_path'], 'berks_config.json')
 
 # OMG please save me from the below horribleness
 execute 'rsync user keys' do
-  command "rsync -avz --delete -e 'ssh -i #{private_key_path}' root@#{ecm_topo.bootstrap_host_name}:/srv/piab/users/ #{users_path}"
+  command "rsync -avz --delete -e 'ssh -i #{private_key_path} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' root@#{ecm_topo.bootstrap_host_name}:/srv/piab/users/ #{users_path}"
   action :run
 end
 

--- a/cookbooks/private-chef/libraries/org_torturer.rb
+++ b/cookbooks/private-chef/libraries/org_torturer.rb
@@ -1,0 +1,68 @@
+# encoding: utf-8
+
+require 'chef/resource/lwrp_base'
+
+class Chef
+  class Resource
+    class OrgTorturer < Chef::Resource::LWRPBase
+      self.resource_name = :org_torturer
+      actions :create
+      default_action :create
+      attribute :knife_opc_cmd, :kind_of => String, :default => nil
+    end
+  end
+end
+
+require 'chef/provider/lwrp_base'
+
+class Chef
+  class Provider
+    class OrgTorturer < Chef::Provider::LWRPBase
+      use_inline_resources
+
+      ADMIN_USER = 'pinkiepie'
+      NUM_ORGS = 900
+
+      action :create do
+        USER_ROOT = node['private-chef']['user_root']
+        DOMAIN_NAME = TopoHelper.new(ec_config: node['private-chef']).mydomainname
+        KNIFE_OPC_CMD = new_resource.knife_opc_cmd
+
+        directory USER_ROOT do
+          action :create
+          recursive true
+        end
+
+        generate_orgs(1..NUM_ORGS)
+      end
+
+      def generate_orgs(organizations)
+        organizations.each do |orgname|
+          create_org("org#{orgname}")
+        end
+      end
+
+      def create_org(orgname)
+        validator_file = "#{USER_ROOT}/#{orgname}-validator.pem"
+        execute "create_org_#{orgname}" do
+          command "#{KNIFE_OPC_CMD} org create #{orgname} #{orgname} -f #{validator_file}"
+          action :run
+          not_if "test -f #{validator_file}"
+          notifies :run, "execute[associate_user_#{ADMIN_USER}_to_org_#{orgname}]", :immediately
+        end
+
+        execute "associate_user_#{ADMIN_USER}_to_org_#{orgname}" do
+          cmd_args = [
+                      KNIFE_OPC_CMD, 'org', 'user', 'add',
+                      orgname,
+                      ADMIN_USER,
+                      '--admin'
+                     ]
+          command cmd_args.join(' ')
+          action :nothing
+        end
+      end
+
+    end
+  end
+end

--- a/cookbooks/private-chef/providers/backend_storage.rb
+++ b/cookbooks/private-chef/providers/backend_storage.rb
@@ -172,12 +172,16 @@ def create_drbd_dirs
 end
 
 def fstype
-  if system('which mkfs.ext4')
+  if node['platform_family'] == 'debian' || node['platform'] == 'centos'
+    package 'xfsprogs'
+    'xfs'
+  elsif system('which mkfs.ext4')
     'ext4'
   else
     'ext3'
   end
 end
+
 
 def create_lvm(disks, mountpoint = nil)
   stupid_chown_trick = false

--- a/cookbooks/private-chef/recipes/ec2.rb
+++ b/cookbooks/private-chef/recipes/ec2.rb
@@ -60,33 +60,34 @@ execute 'Remove /mnt from fstab' do
   only_if 'grep /mnt /etc/fstab'
 end
 
-case node['platform_family']
-when 'rhel'
-  %w(gcc libxml2-devel libxslt-devel).each do |develpkg|
-    package develpkg
-  end
-when 'debian'
-  include_recipe 'apt'
-  %w(build-essential libxslt-dev libxml2-dev).each do |develpkg|
-    package develpkg
-  end
-end
+# not needed now with ChefDK
+# case node['platform_family']
+# when 'rhel'
+#   %w(gcc libxml2-devel libxslt-devel).each do |develpkg|
+#     package develpkg
+#   end
+# when 'debian'
+#   include_recipe 'apt'
+#   %w(build-essential libxslt-dev libxml2-dev).each do |develpkg|
+#     package develpkg
+#   end
+# end
 
-# temporary workaround until Nokogiri is fixed again - IP 11/11/2014
-gem_package 'nokogiri' do
-  gem_binary('/opt/chef/embedded/bin/gem')
-  version '1.6.3.1'
-  if node['platform_family'] == 'rhel'
-    options('--no-rdoc --no-ri -- --use-system-libraries')
-  else
-    options('--no-rdoc --no-ri')
-  end
-end
+# # temporary workaround until Nokogiri is fixed again - IP 11/11/2014
+# gem_package 'nokogiri' do
+#   gem_binary('/opt/chef/embedded/bin/gem')
+#   version '1.6.3.1'
+#   if node['platform_family'] == 'rhel'
+#     options('--no-rdoc --no-ri -- --use-system-libraries')
+#   else
+#     options('--no-rdoc --no-ri')
+#   end
+# end
 
-gem_package 'fog' do
-  gem_binary('/opt/chef/embedded/bin/gem')
-  options('--no-rdoc --no-ri')
-end
+# gem_package 'fog' do
+#   gem_binary('/opt/chef/embedded/bin/gem')
+#   options('--no-rdoc --no-ri')
+# end
 
 directory '/var/opt/opscode/keepalived/bin' do
   owner 'root'

--- a/cookbooks/private-chef/recipes/org_torture.rb
+++ b/cookbooks/private-chef/recipes/org_torture.rb
@@ -1,0 +1,5 @@
+# encoding: utf-8
+
+org_torturer "herewego" do
+  knife_opc_cmd '/opt/opscode/embedded/bin/knife-opc'
+end

--- a/lib/tasks/multiorg_cookbook_uploader.rake
+++ b/lib/tasks/multiorg_cookbook_uploader.rake
@@ -92,11 +92,15 @@ end
 
 task :multiorg_uploader => [:multiorg_prep] do
   (1..num_orgs).in_parallel_n(parallel_uploaders) do |orgnum|
+    start_time = Time.now
     orgname = "org#{orgnum}"
-    puts "Uploading STARTING to org #{orgname}"
+    puts "Uploading STARTING to org #{orgname} at #{start_time.to_s}"
     berks_config_file = ::File.join(BERKS_CONFIG_DIR, "#{orgname}.json")
     sh "#{HARNESS_KNIFE_BIN} upload /cookbooks -s #{chef_server_url(orgname)} -k #{CHEF_USER_PEM} -u #{CHEF_USER} -c #{HARNESS_KNIFE_CONFIG}"
     sh "#{BERKS_BIN} upload -c #{berks_config_file}"
-    puts "Uploading COMPLETE to org #{orgname}"
+    end_time = Time.now
+    duration_secs = end_time.to_i - start_time.to_i
+    puts "Uploading COMPLETE to org #{orgname} at #{end_time}"
+    puts "STATS #{orgname} #{duration_secs}"
   end
 end

--- a/lib/tasks/multiorg_cookbook_uploader.rake
+++ b/lib/tasks/multiorg_cookbook_uploader.rake
@@ -1,8 +1,7 @@
 require_relative '../../cookbooks/ec-common/libraries/topo_helper'
-
+require 'resolv'
 
 # cargo culted from: http://t-a-w.blogspot.com/2010/05/very-simple-parallelization-with-ruby.html
-
 def Exception.ignoring_exceptions
   begin
     yield

--- a/lib/tasks/multiorg_cookbook_uploader.rake
+++ b/lib/tasks/multiorg_cookbook_uploader.rake
@@ -1,0 +1,102 @@
+require_relative '../../cookbooks/ec-common/libraries/topo_helper'
+
+
+# cargo culted from: http://t-a-w.blogspot.com/2010/05/very-simple-parallelization-with-ruby.html
+
+def Exception.ignoring_exceptions
+  begin
+    yield
+  rescue Exception => e
+    STDERR.puts e.message
+  end
+end
+
+require 'thread'
+module Enumerable
+  def in_parallel_n(n)
+    todo = Queue.new
+    ts = (1..n).map{
+      Thread.new{
+        while x = todo.deq
+          Exception.ignoring_exceptions{ yield(x[0]) }
+        end
+      }
+    }
+    each{|x| todo << [x]}
+    n.times{ todo << nil }
+    ts.each{|t| t.join}
+  end
+end
+
+harness_dir = ENV['HARNESS_DIR'] = EcMetal::Api.harness_dir
+repo_dir = ENV['ECM_CHEF_REPO'] = EcMetal::Api.repo_dir
+
+config = get_config
+topo = TopoHelper.new(ec_config: config['layout'])
+
+PRIVATE_KEY_PATH = ::File.join(repo_dir, 'keys', 'id_rsa')
+USERS_PATH = ::File.join(harness_dir, 'users')
+# chef_org = 'ponyville'
+# chef_org_validation_pem = ::File.join(users_path, "#{chef_org}-validator.pem")
+CHEF_USER = 'pinkiepie'
+CHEF_USER_PEM = ::File.join(USERS_PATH, CHEF_USER, '.chef', "#{CHEF_USER}.pem")
+if config['ec2_options'] && config['ec2_options']['elb'] && config['ec2_options']['elb'] == true
+  CHEF_SERVER =  fog.get_elb_dns_name(elb_name)
+else
+  CHEF_SERVER = ::Resolv.getaddress(topo.bootstrap_host_name)
+end
+# chef_server_url = "https://#{chef_server}/organizations/#{chef_org}"
+HARNESS_KNIFE_BIN = ::File.join(harness_dir, 'bin', 'knife')
+HARNESS_KNIFE_CONFIG = ::File.join(harness_dir, '.chef', 'knife.rb')
+BERKS_BIN = ::File.join(harness_dir, 'bin', 'berks')
+BERKS_CONFIG_DIR = ::File.join(harness_dir, 'berks_configs')
+
+
+num_orgs = 900
+parallel_uploaders = 10
+
+def chef_server_url(orgname)
+  "https://#{CHEF_SERVER}/organizations/#{orgname}"
+end
+
+def berks_config_json(orgname)
+  {
+    chef: {
+      chef_server_url: chef_server_url(orgname),
+      node_name: CHEF_USER,
+      client_key: CHEF_USER_PEM
+    },
+    ssl: {
+      verify: false
+    }
+  }
+end
+
+task :berks_prep do
+  Dir.mkdir(BERKS_CONFIG_DIR) unless Dir.exists?(BERKS_CONFIG_DIR)
+  berks_config_file = ::File.join(repo_dir, 'berks_config.json')
+  File.open(berks_config_file, 'w') { |file| file.write(JSON.dump(berks_config_json('ponyville')))}
+  sh "#{BERKS_BIN} install -c #{berks_config_file} -q"
+end
+
+task :multiorg_prep => [:berks_prep] do
+  sh "rsync -az --delete -e 'ssh -i #{PRIVATE_KEY_PATH}' root@#{topo.bootstrap_host_name}:/srv/piab/users/ #{USERS_PATH}"
+  (1..num_orgs).each do |orgnum|
+    orgname = "org#{orgnum}"
+    puts "Prepping org #{orgname}"
+    berks_config_file = ::File.join(BERKS_CONFIG_DIR, "#{orgname}.json")
+    File.open(berks_config_file, 'w') { |file| file.write(JSON.dump(berks_config_json(orgname)))}
+    # sh "#{BERKS_BIN} install -c #{berks_config_file} -q"
+  end
+end
+
+task :multiorg_uploader => [:multiorg_prep] do
+  (1..num_orgs).in_parallel_n(parallel_uploaders) do |orgnum|
+    orgname = "org#{orgnum}"
+    puts "Uploading STARTING to org #{orgname}"
+    berks_config_file = ::File.join(BERKS_CONFIG_DIR, "#{orgname}.json")
+    sh "#{HARNESS_KNIFE_BIN} upload /cookbooks -s #{chef_server_url(orgname)} -k #{CHEF_USER_PEM} -u #{CHEF_USER} -c #{HARNESS_KNIFE_CONFIG}"
+    sh "#{BERKS_BIN} upload -c #{berks_config_file}"
+    puts "Uploading COMPLETE to org #{orgname}"
+  end
+end

--- a/lib/tasks/multiorg_cookbook_uploader.rake
+++ b/lib/tasks/multiorg_cookbook_uploader.rake
@@ -51,9 +51,7 @@ else
   CHEF_SERVER = resolve_bootstrap_host_name
 end
 # chef_server_url = "https://#{chef_server}/organizations/#{chef_org}"
-HARNESS_KNIFE_BIN = ::File.join(harness_dir, 'bin', 'knife')
 HARNESS_KNIFE_CONFIG = ::File.join(harness_dir, '.chef', 'knife.rb')
-BERKS_BIN = ::File.join(harness_dir, 'bin', 'berks')
 BERKS_CONFIG_DIR = ::File.join(harness_dir, 'berks_configs')
 
 
@@ -81,7 +79,7 @@ task :berks_prep do
   Dir.mkdir(BERKS_CONFIG_DIR) unless Dir.exists?(BERKS_CONFIG_DIR)
   berks_config_file = ::File.join(repo_dir, 'berks_config.json')
   File.open(berks_config_file, 'w') { |file| file.write(JSON.dump(berks_config_json('ponyville')))}
-  sh "#{BERKS_BIN} install -c #{berks_config_file} -q"
+  sh "berks install -c #{berks_config_file} -q"
 end
 
 task :multiorg_prep => [:berks_prep] do
@@ -101,8 +99,8 @@ task :multiorg_uploader => [:multiorg_prep] do
     orgname = "org#{orgnum}"
     puts "Uploading STARTING to org #{orgname} at #{start_time.to_s}"
     berks_config_file = ::File.join(BERKS_CONFIG_DIR, "#{orgname}.json")
-    sh "#{HARNESS_KNIFE_BIN} upload /cookbooks -s #{chef_server_url(orgname)} -k #{CHEF_USER_PEM} -u #{CHEF_USER} -c #{HARNESS_KNIFE_CONFIG}"
-    sh "#{BERKS_BIN} upload -c #{berks_config_file}"
+    sh "knife upload /cookbooks -s #{chef_server_url(orgname)} -k #{CHEF_USER_PEM} -u #{CHEF_USER} -c #{HARNESS_KNIFE_CONFIG}"
+    sh "berks upload -c #{berks_config_file}"
     end_time = Time.now
     duration_secs = end_time.to_i - start_time.to_i
     puts "Uploading COMPLETE to org #{orgname} at #{end_time}"


### PR DESCRIPTION
1.  Org torture mode (disabled by default) creates 900 orgs and provides a multi-threaded cookbook uploader to those orgs.  See this for more information: https://gist.github.com/irvingpop/bf4b983b5db7b5b9cbc7
2.  Make XFS the default filesystem on Ubuntu and CentOS for better performance and scalability
3.  Use the ChefDK on the nodes to greatly speed up the initial provision
4. Pin chef on loadtesters at 12.2.1 to avoid gem version conflicts with knife-container
